### PR TITLE
Updating 2.0 installation instructions to mention GodotNodeInterfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Simply add the following to your project's `.csproj` file. Be sure to specify th
 
 ```xml
 <ItemGroup>
+    <PackageReference Include="Chickensoft.GodotNodeInterfaces" Version="..." />
     <PackageReference Include="Chickensoft.Introspection" Version="..." />
     <PackageReference Include="Chickensoft.Introspection.Generator" Version="..." PrivateAssets="all" OutputItemType="analyzer" />
     <PackageReference Include="Chickensoft.AutoInject" Version="..." PrivateAssets="all" />


### PR DESCRIPTION
After upgrading to 2.0 and looking through the installation instructions, I found that I was unable to compile the `Chickensoft.AutoInject` sources. It turns out this was due to the `Chickensoft.GodotNodeInterfaces` package being missing. I have added those instructions to the README to prevent issues for any others.

This could also be fixed by making it a dependency, but I figured this was the simpler solution since it would not require a new release.