### PR TITLE
fix: deterministic lifecycle

### DIFF
--- a/Chickensoft.AutoInject.Tests/src/auto_connect/IAutoConnect.cs
+++ b/Chickensoft.AutoInject.Tests/src/auto_connect/IAutoConnect.cs
@@ -31,7 +31,7 @@ public interface IAutoConnect : IMixin<IAutoConnect>, IFakeNodeTreeEnabled {
   void IMixin<IAutoConnect>.Handler() {
     var what = MixinState.Get<NotificationState>().Notification;
 
-    if (what == Node.NotificationSceneInstantiated) {
+    if (what == Node.NotificationEnterTree) {
       AutoConnector.ConnectNodes(Types.Graph.GetProperties(GetType()), this);
     }
   }

--- a/Chickensoft.AutoInject.Tests/src/auto_inject/dependent/DependentState.cs
+++ b/Chickensoft.AutoInject.Tests/src/auto_inject/dependent/DependentState.cs
@@ -33,6 +33,11 @@ public class DependentState {
   /// </summary>
   public bool ShouldResolveDependencies { get; set; } = true;
 
+  /// <summary>Set internally when Setup() should be called.</summary>
+  public bool PleaseCallSetup { get; set; }
+  /// <summary>Set internally when OnResolved() should be called.</summary>
+  public bool PleaseCallOnResolved { get; set; }
+
   /// <summary>
   /// Dictionary of providers we are listening to that are still initializing
   /// their provided values. We use this in the rare event that we have to

--- a/Chickensoft.AutoInject.Tests/src/auto_inject/dependent/IDependent.cs
+++ b/Chickensoft.AutoInject.Tests/src/auto_inject/dependent/IDependent.cs
@@ -6,6 +6,8 @@ using Godot;
 using Chickensoft.AutoInject;
 using Chickensoft.Introspection;
 using System.Globalization;
+using System;
+using System.Runtime.CompilerServices;
 
 
 /// <summary>
@@ -13,7 +15,7 @@ using System.Globalization;
 /// resolve dependencies marked with the [Dependency] attribute.
 /// </summary>
 [Mixin]
-public interface IDependent : IMixin<IDependent>, IAutoInit {
+public interface IDependent : IMixin<IDependent>, IAutoInit, IReadyAware {
   DependentState DependentState {
     get {
       AddStateIfNeeded();
@@ -36,6 +38,22 @@ public interface IDependent : IMixin<IDependent>, IAutoInit {
   /// </summary>
   void OnResolved() { }
 
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  void IReadyAware.OnBeforeReady() { }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
+  void IReadyAware.OnAfterReady() {
+    if (DependentState.PleaseCallSetup) {
+      Setup();
+      DependentState.PleaseCallSetup = false;
+    }
+    if (DependentState.PleaseCallOnResolved) {
+      OnResolved();
+      DependentState.PleaseCallOnResolved = false;
+    }
+  }
+
+  [MethodImpl(MethodImplOptions.AggressiveInlining)]
   private void AddStateIfNeeded() {
     if (MixinState.Has<DependentState>()) { return; }
 

--- a/Chickensoft.AutoInject.Tests/src/auto_on/IAutoOn.cs
+++ b/Chickensoft.AutoInject.Tests/src/auto_on/IAutoOn.cs
@@ -102,6 +102,12 @@ public interface IAutoOn : IMixin<IAutoOn> {
         autoNode.OnChildOrderChanged();
         break;
       case (int)Node.NotificationReady:
+        if (node is IReadyAware readyAware) {
+          readyAware.OnBeforeReady();
+          autoNode.OnReady();
+          readyAware.OnAfterReady();
+          break;
+        }
         autoNode.OnReady();
         break;
       case (int)Node.NotificationEditorPostSave:

--- a/Chickensoft.AutoInject.Tests/src/misc/IReadyAware.cs
+++ b/Chickensoft.AutoInject.Tests/src/misc/IReadyAware.cs
@@ -1,0 +1,12 @@
+namespace Chickensoft.AutoInject;
+
+/// <summary>
+/// Types that want to be informed of ready can implement this interface.
+/// </summary>
+public interface IReadyAware {
+  /// <summary>Called right before the node is ready.</summary>
+  void OnBeforeReady();
+
+  /// <summary>Called right after the node is readied.</summary>
+  void OnAfterReady();
+}

--- a/Chickensoft.AutoInject.Tests/test/src/AutoConnectInvalidCastTest.cs
+++ b/Chickensoft.AutoInject.Tests/test/src/AutoConnectInvalidCastTest.cs
@@ -27,7 +27,29 @@ public class AutoConnectInvalidCastTest(Node testScene) : TestClass(testScene) {
     scene.FakeNodeTree(new() { ["Node3D"] = new Mock<INode3D>().Object });
 
     Should.Throw<InvalidOperationException>(
-      () => scene._Notification((int)Node.NotificationSceneInstantiated)
+      () => scene._Notification((int)Node.NotificationEnterTree)
+    );
+  }
+
+  [Test]
+  public void ThrowsIfNoNode() {
+    var scene = new AutoConnectInvalidCastTestScene();
+    Should.Throw<InvalidOperationException>(
+      () => scene._Notification((int)Node.NotificationEnterTree)
+    );
+  }
+
+  [Test]
+  public void ThrowsIfTypeIsWrong() {
+    var scene = new AutoConnectInvalidCastTestScene();
+
+    var node = new Control {
+      Name = "Node3D"
+    };
+    scene.AddChild(node);
+
+    Should.Throw<InvalidOperationException>(
+      () => scene._Notification((int)Node.NotificationEnterTree)
     );
   }
 }

--- a/README.md
+++ b/README.md
@@ -416,6 +416,24 @@ var myNode = new MyNode() {
 
 For example tests, please see the [Game Demo] project.
 
+## 🌱 Enhanced Lifecycle
+
+AutoInject enhances the typical Godot node lifecycle by adding additional hooks that allow you to handle dependencies and initialization in a more controlled manner (primarily for making testing easier).
+
+This is the lifecycle of a dependent node in the game environment:
+
+```text
+Initialize() -> OnReady() -> Setup() -> OnResolved()
+```
+
+Note that this lifecycle is preserved regardless of how the node is added to the scene tree.
+
+And this is the lifecycle of a dependent node in a test environment:
+
+```text
+OnReady() -> OnResolved()
+```
+
 ## 🔋 IAutoOn
 
 The `IAutoOn` mixin allows node scripts to implement .NET-style handler methods for Godot notifications, prefixed with `On`.


### PR DESCRIPTION
- life cycle hooks are now deterministic

  Order will always be `Initialize() -> OnReady() -> Setup() -> OnResolved()`.

- auto connect now connects nodes whenever it enters the tree, as it should have all along.