### PR TITLE
feat: add `this.Notify` and `this.Provide` analyzers and code fixes

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -70,6 +70,7 @@ jobs:
           replace: ${{ steps.next-version.outputs.version }}
           regex: false
           include: Chickensoft.AutoInject/Chickensoft.AutoInject.csproj
+          include: Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
 
       - name: 🖨 Copy Source to Source-Only package
         run: |
@@ -131,10 +132,22 @@ jobs:
         run: |
           dotnet build -c Release
 
+      - name: 🛠 Build Analyzers
+        working-directory: Chickensoft.AutoInject.Analyzers
+        run: |
+          dotnet build -c Release
+
       - name: 🔎 Get Package Path
         id: package-path
         run: |
           package=$(find ./Chickensoft.AutoInject/nupkg -name "*.nupkg")
+          echo "package=$package" >> "$GITHUB_OUTPUT"
+          echo "📦 Found package: $package"
+
+      - name: 🔎 Get Analyzer Package Path
+        id: analyzer-package-path
+        run: |
+          package=$(find ./Chickensoft.AutoInject.Analyzers/nupkg -name "*.nupkg")
           echo "package=$package" >> "$GITHUB_OUTPUT"
           echo "📦 Found package: $package"
 
@@ -144,10 +157,20 @@ jobs:
         run: |
           version="${{ steps.next-version.outputs.version }}"
           gh release create --title "v$version" --generate-notes "$version" \
-            "${{ steps.package-path.outputs.package }}"
+            "${{ steps.package-path.outputs.package }}" \
+            "${{ steps.analyzer-package-path.outputs.package }}"
 
       - name: 🛜 Publish to Nuget
         run: |
           dotnet nuget push "${{ steps.package-path.outputs.package }}" \
+            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --source "https://api.nuget.org/v3/index.json" --skip-duplicate
+
+      - name: 🛜 Publish to Nuget
+        run: |
+          dotnet nuget push "${{ steps.package-path.outputs.package }}" \
+            --api-key "${{ secrets.NUGET_API_KEY }}" \
+            --source "https://api.nuget.org/v3/index.json" --skip-duplicate
+          dotnet nuget push "${{ steps.analyzer-package-path.outputs.package }}" \
             --api-key "${{ secrets.NUGET_API_KEY }}" \
             --source "https://api.nuget.org/v3/index.json" --skip-duplicate

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,16 @@ bin/
 obj/
 .generated/
 .vs/
+.idea/
 .DS_Store
-Chickensoft.AutoInject/nupkg/
+nupkg/
 !Chickensoft.AutoInject/nupkg/.gitkeep
+
+# User-specific files
+*.suo
+*.user
+*.userosscache
+*.sln.docstates
+
+# User-specific files (MonoDevelop/Xamarin Studio)
+*.userprefs

--- a/Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
+++ b/Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
@@ -4,9 +4,9 @@
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IncludeBuildOutput>false</IncludeBuildOutput>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <LangVersion>preview</LangVersion>
     <RootNamespace>Chickensoft.AutoInject.Analyzers</RootNamespace>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NoWarn>NU5128</NoWarn>
     <OutputPath>./nupkg</OutputPath>
     <IsRoslynComponent>true</IsRoslynComponent>
@@ -16,7 +16,7 @@
 
     <Title>AutoInject Analyzers</Title>
     <Version>0.0.0-devbuild</Version>
-    <Description>AutoInject analyzers.</Description>
+    <Description>Analyzers and code fixes for Chickensoft.AutoInject.</Description>
     <Copyright>© 2025 Chickensoft</Copyright>
     <Authors>Chickensoft</Authors>
     <Company>Chickensoft</Company>

--- a/Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
+++ b/Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
@@ -1,0 +1,50 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <ImplicitUsings>disable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <LangVersion>preview</LangVersion>
+    <RootNamespace>Chickensoft.AutoInject.Analyzers</RootNamespace>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <NoWarn>NU5128</NoWarn>
+    <OutputPath>./nupkg</OutputPath>
+    <IsRoslynComponent>true</IsRoslynComponent>
+    <AnalyzerLanguage>cs</AnalyzerLanguage>
+    <EnforceExtendedAnalyzerRules>true</EnforceExtendedAnalyzerRules>
+    <DebugType>portable</DebugType>
+
+    <Title>AutoInject Analyzers</Title>
+    <Version>1.0.0</Version>
+    <Description>AutoInject analyzers.</Description>
+    <Copyright>© 2025 Chickensoft Games</Copyright>
+    <Authors>Chickensoft</Authors>
+    <Company>Chickensoft</Company>
+
+    <PackageId>Chickensoft.AutoInject.Analyzers</PackageId>
+    <PackageReleaseNotes>AutoInject Analyzers release.</PackageReleaseNotes>
+    <PackageIcon>icon.png</PackageIcon>
+    <PackageTags>dependency injection; di; godot; chickensoft; nodes; analyzers; code fixes;</PackageTags>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
+    <PackageProjectUrl>https://github.com/chickensoft-games/AutoInject</PackageProjectUrl>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Has to be in its own item group -->
+    <None Include="./README.md" Pack="true" PackagePath="\" />
+    <None Include="../LICENSE" Pack="true" PackagePath="\" />
+    <None Include="../Chickensoft.AutoInject/icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <!-- The following libraries include the types we need -->
+  <ItemGroup>
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+  </ItemGroup>
+
+  <!-- This ensures the library will be packaged as an analyzer when we use `dotnet pack` -->
+  <ItemGroup>
+    <None Include="$(OutputPath)/$(AssemblyName).dll" Pack="true" PackagePath="analyzers/dotnet/cs" Visible="false" />
+  </ItemGroup>
+</Project>

--- a/Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
+++ b/Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
@@ -15,9 +15,9 @@
     <DebugType>portable</DebugType>
 
     <Title>AutoInject Analyzers</Title>
-    <Version>1.0.0</Version>
+    <Version>0.0.0-devbuild</Version>
     <Description>AutoInject analyzers.</Description>
-    <Copyright>© 2025 Chickensoft Games</Copyright>
+    <Copyright>© 2025 Chickensoft</Copyright>
     <Authors>Chickensoft</Authors>
     <Company>Chickensoft</Company>
 

--- a/Chickensoft.AutoInject.Analyzers/README.md
+++ b/Chickensoft.AutoInject.Analyzers/README.md
@@ -1,0 +1,3 @@
+# AutoInject Analyzers
+
+Checks to ensure you called this.Notify() and this.Provide() when needed in your classes.

--- a/Chickensoft.AutoInject.Analyzers/README.md
+++ b/Chickensoft.AutoInject.Analyzers/README.md
@@ -1,3 +1,8 @@
 # AutoInject Analyzers
 
-Checks to ensure you called this.Notify() and this.Provide() when needed in your classes.
+Roslyn analyzers providing diagnostics and code fixes for common issues using [Chickensoft.AutoInject](https://www.nuget.org/packages/Chickensoft.AutoInject) in Godot node scripts.
+
+Current diagnostics and fixes:
+* Missing override of `void _Notification(int what)`
+* Missing call to `this.Notify()`
+* Missing call to `this.Provide()` for nodes implementing `IProvider`

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyAnalyzer.cs
@@ -14,7 +14,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 public class AutoInjectNotifyAnalyzer : DiagnosticAnalyzer {
   public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics {
     get;
-  } = [Diagnostics.MissingAutoInjectNotifyDescriptor, Diagnostics.MissingAutoInjectNotifyOverrideDescriptor];
+  } = [Diagnostics.MissingAutoInjectNotifyDescriptor, Diagnostics.MissingAutoInjectNotificationOverrideDescriptor];
 
   public override void Initialize(AnalysisContext context) {
     context.EnableConcurrentExecution();
@@ -73,7 +73,7 @@ public class AutoInjectNotifyAnalyzer : DiagnosticAnalyzer {
     if (!hasNotificationOverride) {
       // Report missing Notify call, _Notification override already exists.
       context.ReportDiagnostic(
-        Diagnostics.MissingAutoInjectNotifyOverride(
+        Diagnostics.MissingAutoInjectNotificationOverride(
           attributes[0].GetLocation(),
           classDeclaration.Identifier.ValueText
         )

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyAnalyzer.cs
@@ -1,0 +1,92 @@
+namespace Chickensoft.AutoInject.Analyzers;
+
+using System.Collections.Immutable;
+using System.Linq;
+using Chickensoft.AutoInject.Analyzers.Utils;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+#pragma warning disable RS1038 // This is safe to disable as Microsoft.CodeAnalysis.Workspaces is only referenced in code fixes and not in the analyzer itself.
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+#pragma warning restore RS1038
+public class AutoInjectNotifyAnalyzer : DiagnosticAnalyzer
+{
+  public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics {
+    get;
+  } = [Diagnostics.MissingAutoInjectNotifyDescriptor, Diagnostics.MissingAutoInjectNotifyOverrideDescriptor];
+
+  public override void Initialize(AnalysisContext context) {
+    context.EnableConcurrentExecution();
+
+    context.ConfigureGeneratedCodeAnalysis(
+      GeneratedCodeAnalysisFlags.Analyze |
+      GeneratedCodeAnalysisFlags.ReportDiagnostics
+    );
+
+    context.RegisterSyntaxNodeAction(
+      AnalyzeClassDeclaration,
+      SyntaxKind.ClassDeclaration
+    );
+  }
+
+  private static void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context) {
+    var classDeclaration = (ClassDeclarationSyntax)context.Node;
+
+    var attributes = classDeclaration.AttributeLists.SelectMany(list => list.Attributes
+    ).Where(attribute => attribute.Name.ToString() == Constants.META_ATTRIBUTE_NAME
+       // Check that Meta attribute has an AutoInject type (ex: [Meta(typeof(IAutoNode))])
+       && attribute.ArgumentList?.Arguments.Any(arg =>
+          arg.Expression is TypeOfExpressionSyntax { Type: IdentifierNameSyntax identifierName } &&
+         Constants.AutoInjectTypeNames.Contains(identifierName.Identifier.ValueText)
+       ) == true
+    )
+    .ToList();
+
+    if (attributes.Count == 0) {
+      return;
+    }
+
+    // Check if the class calls "this.Notify()" anywhere.
+    var hasNotify = classDeclaration
+      .DescendantNodes()
+      .OfType<InvocationExpressionSyntax>()
+      .Any(invocation =>
+        invocation.Expression is MemberAccessExpressionSyntax {
+          Name.Identifier.ValueText: "Notify", Expression: ThisExpressionSyntax
+        });
+
+    if (hasNotify) {
+      return;
+    }
+
+    // Check if the class has a _Notification override method.
+    var hasNotificationOverride = classDeclaration
+      .Members
+      .OfType<MethodDeclarationSyntax>()
+      .Any(method =>
+        method.Identifier.ValueText == "_Notification" &&
+        method.Modifiers.Any(SyntaxKind.OverrideKeyword) &&
+        method.ParameterList.Parameters.Count == 1
+      );
+
+    if (!hasNotificationOverride) {
+      // Report missing Notify call, _Notification override already exists.
+      context.ReportDiagnostic(
+        Diagnostics.MissingAutoInjectNotifyOverride(
+          attributes[0].GetLocation(),
+          classDeclaration.Identifier.ValueText
+        )
+      );
+    } else {
+      // Report missing Notify call, _Notification override does not exist.
+      context.ReportDiagnostic(
+        Diagnostics.MissingAutoInjectNotify(
+          attributes[0].GetLocation(),
+          classDeclaration.Identifier.ValueText
+        )
+      );
+    }
+  }
+}

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyAnalyzer.cs
@@ -11,8 +11,7 @@ using Microsoft.CodeAnalysis.Diagnostics;
 #pragma warning disable RS1038 // This is safe to disable as Microsoft.CodeAnalysis.Workspaces is only referenced in code fixes and not in the analyzer itself.
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 #pragma warning restore RS1038
-public class AutoInjectNotifyAnalyzer : DiagnosticAnalyzer
-{
+public class AutoInjectNotifyAnalyzer : DiagnosticAnalyzer {
   public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics {
     get;
   } = [Diagnostics.MissingAutoInjectNotifyDescriptor, Diagnostics.MissingAutoInjectNotifyOverrideDescriptor];
@@ -79,7 +78,8 @@ public class AutoInjectNotifyAnalyzer : DiagnosticAnalyzer
           classDeclaration.Identifier.ValueText
         )
       );
-    } else {
+    }
+    else {
       // Report missing Notify call, _Notification override does not exist.
       context.ReportDiagnostic(
         Diagnostics.MissingAutoInjectNotify(

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
@@ -37,9 +37,10 @@ public class AutoInjectProvideAnalyzer : DiagnosticAnalyzer {
   private void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context) {
     var classDeclaration = (ClassDeclarationSyntax)context.Node;
 
-    // This warning is only relevant for classes that implement IProvide<T>
-    var implementsIProvide = classDeclaration.BaseList?.Types
-      .Any(baseType => baseType.Type is GenericNameSyntax { Identifier.ValueText: Constants.PROVIDER_INTERFACE_NAME, TypeArgumentList.Arguments.Count: > 0 }) ?? false;
+    // Check that IProvide is implemented by the class, as these are the only classes that need to call Provide().
+    var classSymbol = context.SemanticModel.GetDeclaredSymbol(classDeclaration, context.CancellationToken);
+    var implementsIProvide = classSymbol?.AllInterfaces
+      .Any(i => i.Name == Constants.PROVIDER_INTERFACE_NAME && i.IsGenericType) == true;
 
     if (!implementsIProvide) {
       return;

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
@@ -1,0 +1,85 @@
+namespace Chickensoft.AutoInject.Analyzers;
+
+using System.Collections.Immutable;
+using System.Linq;
+using Utils;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Diagnostics;
+
+/// <summary>
+/// When inheriting IProvide, the class must call this.Provide() somewhere in the setup.
+/// This analyzer checks that the class does not forget to call this.Provide().
+/// </summary>
+#pragma warning disable RS1038 // This is safe to disable as Microsoft.CodeAnalysis.Workspaces is only referenced in code fixes and not in the analyzer itself.
+[DiagnosticAnalyzer(LanguageNames.CSharp)]
+#pragma warning restore RS1038
+public class AutoInjectProvideAnalyzer : DiagnosticAnalyzer {
+  public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics {
+    get;
+  } = [Diagnostics.MissingAutoInjectProvideDescriptor];
+
+  public override void Initialize(AnalysisContext context) {
+    context.EnableConcurrentExecution();
+
+    context.ConfigureGeneratedCodeAnalysis(
+      GeneratedCodeAnalysisFlags.Analyze |
+      GeneratedCodeAnalysisFlags.ReportDiagnostics
+    );
+
+    context.RegisterSyntaxNodeAction(
+      AnalyzeClassDeclaration,
+      SyntaxKind.ClassDeclaration
+    );
+  }
+
+  private void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context) {
+    var classDeclaration = (ClassDeclarationSyntax)context.Node;
+
+    // This warning is only relevant for classes that implement IProvide<T>
+    var implementsIProvide = classDeclaration.BaseList?.Types
+      .Any(baseType => baseType.Type is GenericNameSyntax { Identifier.ValueText: Constants.PROVIDER_INTERFACE_NAME, TypeArgumentList.Arguments.Count: > 0 }) ?? false;
+
+    if (!implementsIProvide) {
+      return;
+    }
+
+    // Check that Meta attribute has an AutoInject Provider type (ex: [Meta(typeof(IAutoNode))])
+    var attributes = classDeclaration.AttributeLists.SelectMany(list => list.Attributes
+      ).Where(attribute => attribute.Name.ToString() == Constants.META_ATTRIBUTE_NAME
+         && attribute.ArgumentList?.Arguments.Any(arg =>
+           arg.Expression is TypeOfExpressionSyntax { Type: IdentifierNameSyntax identifierName } &&
+           Constants.ProviderMetaNames.Contains(identifierName.Identifier.ValueText)
+         ) == true
+      )
+      .ToList();
+
+    if (attributes.Count == 0) {
+      return;
+    }
+
+    const string provideMethodName = "Provide";
+
+    // Check if the class calls "this.Provide()" anywhere
+    var hasProvide = classDeclaration
+      .DescendantNodes()
+      .OfType<InvocationExpressionSyntax>()
+      .Any(invocation =>
+        invocation.Expression is MemberAccessExpressionSyntax {
+          Name.Identifier.ValueText: provideMethodName, Expression: ThisExpressionSyntax
+        });
+
+    if (hasProvide) {
+      return;
+    }
+
+    // No provide call found, report the diagnostic
+    context.ReportDiagnostic(
+      Diagnostics.MissingAutoInjectProvide(
+        attributes[0].GetLocation(),
+        classDeclaration.Identifier.ValueText
+      )
+    );
+  }
+}

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
@@ -1,4 +1,4 @@
-namespace Chickensoft.AutoInject.Analyzers.fixes;
+namespace Chickensoft.AutoInject.Analyzers.Fixes;
 
 using System.Collections.Immutable;
 using System.Composition;

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
@@ -40,8 +40,10 @@ public class AutoInjectNotifyMissingFixProvider : CodeFixProvider {
       CodeAction.Create(
         title: "Add \"this.Notify(what);\" to existing \"_Notification\" override",
         createChangedDocument: c => AddAutoInjectNotifyCallAsync(context.Document, typeDeclaration, c),
-        equivalenceKey: nameof(AutoInjectNotifyOverrideFixProvider)),
-      diagnostic);
+        equivalenceKey: nameof(AutoInjectNotifyOverrideFixProvider)
+      ),
+      diagnostic
+    );
   }
 
   private static async Task<Document> AddAutoInjectNotifyCallAsync(Document document,
@@ -86,7 +88,8 @@ public class AutoInjectNotifyMissingFixProvider : CodeFixProvider {
             SyntaxFactory.SingletonSeparatedList(
                 SyntaxFactory.Argument(SyntaxFactory.IdentifierName(actualParameterName))
             )
-        ))
+        )
+    )
     ).WithAdditionalAnnotations(Formatter.Annotation);
 
     // Add the statement to the method body

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
@@ -40,7 +40,7 @@ public class AutoInjectNotifyMissingFixProvider : CodeFixProvider {
       CodeAction.Create(
         title: "Add \"this.Notify(what);\" to existing \"_Notification\" override",
         createChangedDocument: c => AddAutoInjectNotifyCallAsync(context.Document, typeDeclaration, c),
-        equivalenceKey: nameof(AutoInjectNotifyOverrideFixProvider)
+        equivalenceKey: nameof(AutoInjectNotificationOverrideFixProvider)
       ),
       diagnostic
     );

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
@@ -1,0 +1,101 @@
+namespace Chickensoft.AutoInject.Analyzers.fixes;
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Utils;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AutoInjectNotifyMissingFixProvider)), Shared]
+public class AutoInjectNotifyMissingFixProvider : CodeFixProvider {
+  public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+    [Diagnostics.MissingAutoInjectNotifyDescriptor.Id];
+
+  public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+  public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context) {
+    var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+    if (root is null) {
+      return;
+    }
+
+    var diagnostic = context.Diagnostics.First();
+    var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+    // Find the type declaration identified by the diagnostic
+    var typeDeclaration = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf()
+      .OfType<TypeDeclarationSyntax>().FirstOrDefault();
+    if (typeDeclaration is null) {
+      return;
+    }
+
+    context.RegisterCodeFix(
+      CodeAction.Create(
+        title: "Add \"this.Notify(what);\" to existing \"_Notification\" override",
+        createChangedDocument: c => AddAutoInjectNotifyCallAsync(context.Document, typeDeclaration, c),
+        equivalenceKey: nameof(AutoInjectNotifyOverrideFixProvider)),
+      diagnostic);
+  }
+
+  private static async Task<Document> AddAutoInjectNotifyCallAsync(Document document,
+    TypeDeclarationSyntax typeDeclaration, CancellationToken cancellationToken)
+  {
+    const string methodNameToFind = "_Notification"; // The name of the method we're looking for
+
+    // Find the method with the specified name and a single parameter of type int
+    var methodAndParameter = typeDeclaration.Members
+      .OfType<MethodDeclarationSyntax>()
+      .Where(m => m.Identifier.ValueText == methodNameToFind && m.ParameterList.Parameters.Count == 1)
+      .Select(m => new {
+        Method = m,
+        Parameter = m.ParameterList.Parameters.FirstOrDefault(p =>
+          p.Type is PredefinedTypeSyntax pts && pts.Keyword.IsKind(SyntaxKind.IntKeyword))
+      })
+      .FirstOrDefault();
+
+    var originalMethodNode = methodAndParameter?.Method;
+    var parameterSyntax = methodAndParameter?.Parameter;
+
+    if (originalMethodNode is null || parameterSyntax is null)
+    {
+        // Expected method not found or parameter is missing
+        return document;
+    }
+
+    // Get the actual name of the parameter from the found method
+    // It really should be "what", but this makes it more robust to changes in the parameter name
+    var actualParameterName = parameterSyntax.Identifier.ValueText;
+
+    // Construct the statement to add
+    const string methodToInvokeName = "Notify";
+
+    var statementToAdd = SyntaxFactory.ExpressionStatement(
+        SyntaxFactory.InvocationExpression(
+            SyntaxFactory.MemberAccessExpression(
+                SyntaxKind.SimpleMemberAccessExpression,
+                SyntaxFactory.ThisExpression(),
+                SyntaxFactory.IdentifierName(methodToInvokeName)))
+        .WithArgumentList(SyntaxFactory.ArgumentList(
+            SyntaxFactory.SingletonSeparatedList(
+                SyntaxFactory.Argument(SyntaxFactory.IdentifierName(actualParameterName))
+            )
+        ))
+    ).WithAdditionalAnnotations(Formatter.Annotation);
+
+    // Add the statement to the method body
+    return await MethodModifier.AddStatementToMethodBodyAsync(
+        document,
+        typeDeclaration,
+        originalMethodNode,
+        statementToAdd,
+        cancellationToken
+    );
+  }
+}

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyOverrideFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyOverrideFixProvider.cs
@@ -1,4 +1,4 @@
-namespace Chickensoft.AutoInject.Analyzers.fixes;
+namespace Chickensoft.AutoInject.Analyzers.Fixes;
 
 using System.Collections.Immutable;
 using System.Composition;

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyOverrideFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyOverrideFixProvider.cs
@@ -1,0 +1,95 @@
+namespace Chickensoft.AutoInject.Analyzers.fixes;
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
+using Utils;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AutoInjectNotifyOverrideFixProvider)), Shared]
+public class AutoInjectNotifyOverrideFixProvider : CodeFixProvider {
+  public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+    [Diagnostics.MissingAutoInjectNotifyOverrideDescriptor.Id];
+
+  public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+  public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context) {
+    var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+    if (root is null) {
+      return;
+    }
+
+    var diagnostic = context.Diagnostics.First();
+    var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+    // Find the type declaration identified by the diagnostic
+    var typeDeclaration = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf()
+      .OfType<TypeDeclarationSyntax>().FirstOrDefault();
+    if (typeDeclaration is null) {
+      return;
+    }
+
+    context.RegisterCodeFix(
+      CodeAction.Create(
+        title: "Add \"public override void _Notification(int what) => this.Notify(what);\" method",
+        createChangedDocument: c => AddAutoInjectNotifyOverrideAsync(context.Document, typeDeclaration, c),
+        equivalenceKey: nameof(AutoInjectNotifyOverrideFixProvider)),
+      diagnostic);
+  }
+
+  private static async Task<Document> AddAutoInjectNotifyOverrideAsync(Document document,
+    TypeDeclarationSyntax typeDeclaration, CancellationToken cancellationToken)
+  {
+
+    var methodDeclaration = SyntaxFactory.MethodDeclaration(
+        SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)),
+        "_Notification")
+      .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword),
+        SyntaxFactory.Token(SyntaxKind.OverrideKeyword)))
+      .WithParameterList(SyntaxFactory.ParameterList(SyntaxFactory.SingletonSeparatedList(
+        SyntaxFactory.Parameter(SyntaxFactory.Identifier("what"))
+          .WithType(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.IntKeyword))))));
+
+    var expressionBody = SyntaxFactory.InvocationExpression(
+        SyntaxFactory.MemberAccessExpression(
+          SyntaxKind.SimpleMemberAccessExpression,
+          SyntaxFactory.ThisExpression(),
+          SyntaxFactory.IdentifierName("Notify")))
+      .WithArgumentList(SyntaxFactory.ArgumentList(
+        SyntaxFactory.SingletonSeparatedList(
+          SyntaxFactory.Argument(SyntaxFactory.IdentifierName("what")))));
+
+    var arrowExpressionClause = SyntaxFactory.ArrowExpressionClause(expressionBody)
+      .WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation);
+
+    methodDeclaration = methodDeclaration
+      .WithExpressionBody(arrowExpressionClause)
+      .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.SemicolonToken));
+
+    // Insert the new method at the beginning of the class members
+    var existingMembers = typeDeclaration.Members;
+    var newMembers = existingMembers.Insert(0, methodDeclaration);
+
+    // Update the type declaration with the new list of members
+    var newTypeDeclaration = typeDeclaration.WithMembers(newMembers);
+
+    // Get the current root and replace the type declaration
+    var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+    if (root is null) {
+      return document;
+    }
+
+    var newRoot = root.ReplaceNode(typeDeclaration, newTypeDeclaration);
+
+    // Return the updated document.
+    return document.WithSyntaxRoot(newRoot);
+  }
+}

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyOverrideFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyOverrideFixProvider.cs
@@ -14,10 +14,10 @@ using Microsoft.CodeAnalysis.Formatting;
 using Microsoft.CodeAnalysis.Simplification;
 using Utils;
 
-[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AutoInjectNotifyOverrideFixProvider)), Shared]
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AutoInjectNotificationOverrideFixProvider)), Shared]
 public class AutoInjectNotificationOverrideFixProvider : CodeFixProvider {
   public sealed override ImmutableArray<string> FixableDiagnosticIds =>
-    [Diagnostics.MissingAutoInjectNotifyOverrideDescriptor.Id];
+    [Diagnostics.MissingAutoInjectNotificationOverrideDescriptor.Id];
 
   public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
 
@@ -40,12 +40,12 @@ public class AutoInjectNotificationOverrideFixProvider : CodeFixProvider {
     context.RegisterCodeFix(
       CodeAction.Create(
         title: "Add \"public override void _Notification(int what) => this.Notify(what);\" method",
-        createChangedDocument: c => AddAutoInjectNotifyOverrideAsync(context.Document, typeDeclaration, c),
-        equivalenceKey: nameof(AutoInjectNotifyOverrideFixProvider)),
+        createChangedDocument: c => AddAutoInjectNotificationOverrideAsync(context.Document, typeDeclaration, c),
+        equivalenceKey: nameof(AutoInjectNotificationOverrideFixProvider)),
       diagnostic);
   }
 
-  private static async Task<Document> AddAutoInjectNotifyOverrideAsync(Document document,
+  private static async Task<Document> AddAutoInjectNotificationOverrideAsync(Document document,
     TypeDeclarationSyntax typeDeclaration, CancellationToken cancellationToken)
   {
 

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyOverrideFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyOverrideFixProvider.cs
@@ -15,7 +15,7 @@ using Microsoft.CodeAnalysis.Simplification;
 using Utils;
 
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AutoInjectNotifyOverrideFixProvider)), Shared]
-public class AutoInjectNotifyOverrideFixProvider : CodeFixProvider {
+public class AutoInjectNotificationOverrideFixProvider : CodeFixProvider {
   public sealed override ImmutableArray<string> FixableDiagnosticIds =>
     [Diagnostics.MissingAutoInjectNotifyOverrideDescriptor.Id];
 

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectProvideFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectProvideFixProvider.cs
@@ -1,4 +1,4 @@
-namespace Chickensoft.AutoInject.Analyzers.fixes;
+namespace Chickensoft.AutoInject.Analyzers.Fixes;
 
 using System;
 using System.Collections.Generic;

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectProvideFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectProvideFixProvider.cs
@@ -1,0 +1,139 @@
+namespace Chickensoft.AutoInject.Analyzers.fixes;
+
+using System.Collections.Immutable;
+using System.Composition;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CodeFixes;
+using Microsoft.CodeAnalysis.CodeActions;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Simplification;
+using Utils;
+
+[ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AutoInjectProvideFixProvider)), Shared]
+public class AutoInjectProvideFixProvider : CodeFixProvider {
+  public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+    [Diagnostics.MissingAutoInjectProvideDescriptor.Id];
+
+  public sealed override FixAllProvider GetFixAllProvider() => WellKnownFixAllProviders.BatchFixer;
+
+  public sealed override async Task RegisterCodeFixesAsync(CodeFixContext context) {
+    var root = await context.Document.GetSyntaxRootAsync(context.CancellationToken).ConfigureAwait(false);
+    if (root is null) {
+      return;
+    }
+
+    var diagnostic = context.Diagnostics.First();
+    var diagnosticSpan = diagnostic.Location.SourceSpan;
+
+    // Find the type declaration identified by the diagnostic.
+    var typeDeclaration = root.FindToken(diagnosticSpan.Start).Parent?.AncestorsAndSelf()
+      .OfType<TypeDeclarationSyntax>().FirstOrDefault();
+    if (typeDeclaration is null) {
+      return;
+    }
+
+    var hasSetupMethod = typeDeclaration.Members
+      .OfType<MethodDeclarationSyntax>()
+      .Any(m => m.Identifier.Text == "Setup" && m.Modifiers.Any(SyntaxKind.PublicKeyword));
+
+    var hasOnReadyMethod = typeDeclaration.Members
+      .OfType<MethodDeclarationSyntax>()
+      .Any(m => m.Identifier.Text == "OnReady" && m.Modifiers.Any(SyntaxKind.PublicKeyword));
+
+    var hasOnReadyOverride = typeDeclaration.Members
+      .OfType<MethodDeclarationSyntax>()
+      .Any(m => m.Identifier.Text == "_Ready" && m.Modifiers.Any(SyntaxKind.PublicKeyword) &&
+                m.Modifiers.Any(SyntaxKind.OverrideKeyword));
+
+    // If they have Setup(), suggest adding this.Provide() at the end of it.
+    if (hasSetupMethod) {
+      var setupMethod = typeDeclaration.Members
+        .OfType<MethodDeclarationSyntax>()
+        .First(m => m.Identifier.Text == "Setup" && m.Modifiers.Any(SyntaxKind.PublicKeyword));
+
+      context.RegisterCodeFix(
+        CodeAction.Create(
+          title: "Add \"this.Provide();\" to existing \"Setup()\" method",
+          createChangedDocument: c => MethodModifier.AddCallToMethod(context.Document, typeDeclaration, setupMethod, "Provide", c),
+          equivalenceKey: nameof(AutoInjectProvideFixProvider)),
+        diagnostic);
+    } else {
+      // If they don't have Setup(), suggest creating one with this.Provide() in it.
+      context.RegisterCodeFix(
+        CodeAction.Create(
+          title: "Create \"Setup()\" method that calls \"this.Provide();\"",
+          createChangedDocument: c => AddNewMethodAsync(context.Document, typeDeclaration, "Setup", c),
+          equivalenceKey: nameof(AutoInjectProvideFixProvider)),
+        diagnostic);
+    }
+
+    // If they have OnReady(), suggest adding this.Provide() at the end of it.
+    if (hasOnReadyMethod) {
+      var onReadyMethod = typeDeclaration.Members
+        .OfType<MethodDeclarationSyntax>()
+        .First(m => m.Identifier.Text == "OnReady" && m.Modifiers.Any(SyntaxKind.PublicKeyword));
+
+      context.RegisterCodeFix(
+        CodeAction.Create(
+          title: "Add \"this.Provide();\" to existing \"OnReady()\" method",
+          createChangedDocument: c => MethodModifier.AddCallToMethod(context.Document, typeDeclaration, onReadyMethod, "Provide", c),
+          equivalenceKey: nameof(AutoInjectProvideFixProvider)),
+        diagnostic);
+    } else {
+      // If they don't have OnReady(), suggest creating one with this.Provide() in it.
+      context.RegisterCodeFix(
+        CodeAction.Create(
+          title: "Create \"OnReady()\" method that calls \"this.Provide();\"",
+          createChangedDocument: c => AddNewMethodAsync(context.Document, typeDeclaration, "OnReady", c),
+          equivalenceKey: nameof(AutoInjectProvideFixProvider)),
+        diagnostic);
+    }
+
+    // If they have _Ready(), suggest adding this.Provide() at the end of it.
+    if (hasOnReadyOverride) {
+      var onReadyOverrideMethod = typeDeclaration.Members
+        .OfType<MethodDeclarationSyntax>()
+        .First(m => m.Identifier.Text == "_Ready" && m.Modifiers.Any(SyntaxKind.PublicKeyword) &&
+                    m.Modifiers.Any(SyntaxKind.OverrideKeyword));
+
+      context.RegisterCodeFix(
+        CodeAction.Create(
+          title: "Add \"this.Provide();\" to existing \"_Ready()\" method",
+          createChangedDocument: c => MethodModifier.AddCallToMethod(context.Document, typeDeclaration, onReadyOverrideMethod, "Provide", c),
+          equivalenceKey: nameof(AutoInjectProvideFixProvider)),
+        diagnostic);
+    }
+  }
+
+  private static async Task<Document> AddNewMethodAsync(Document document, TypeDeclarationSyntax typeDeclaration, string identifier,
+    CancellationToken cancellationToken) {
+
+    // Create the new method
+    var mewMethod = SyntaxFactory
+      .MethodDeclaration(SyntaxFactory.PredefinedType(SyntaxFactory.Token(SyntaxKind.VoidKeyword)), identifier)
+      .WithModifiers(SyntaxFactory.TokenList(SyntaxFactory.Token(SyntaxKind.PublicKeyword)))
+      .WithBody(SyntaxFactory.Block(
+        SyntaxFactory.SingletonList(
+          SyntaxFactory.ParseStatement(Constants.PROVIDE_NEW_METHOD_BODY)
+            .WithAdditionalAnnotations(Formatter.Annotation, Simplifier.Annotation)
+        )
+      ));
+
+    // Add the new method to the class
+    var newTypeDeclaration = typeDeclaration.AddMembers(mewMethod);
+    // Replace the old type declaration with the new one
+    var root = await document.GetSyntaxRootAsync(cancellationToken);
+    if (root is null) {
+      return document;
+    }
+
+    var newRoot = root.ReplaceNode(typeDeclaration, newTypeDeclaration);
+    // Return the updated document
+    return document.WithSyntaxRoot(newRoot);
+  }
+}

--- a/Chickensoft.AutoInject.Analyzers/src/utils/Constants.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/utils/Constants.cs
@@ -1,0 +1,34 @@
+namespace Chickensoft.AutoInject.Analyzers.Utils;
+
+public static class Constants {
+  public const string META_ATTRIBUTE_NAME = "Meta";
+
+  /// <summary>
+  /// Type names that we look for in Meta attributes to determine if a class needs a this.Provide() call.
+  /// </summary>
+  public static readonly string[] ProviderMetaNames = [
+    "IAutoNode",
+    "IProvider",
+  ];
+
+  public const string PROVIDER_INTERFACE_NAME = "IProvide";
+
+  /// <summary>
+  /// Type names that we look for in Meta attributes to determine if a class needs a this.Notify(what) call.
+  /// </summary>
+  public static readonly string[] AutoInjectTypeNames = [
+    "IAutoNode",
+    "IAutoOn",
+    "IAutoConnect",
+    "IAutoInit",
+    "IProvider",
+    "IDependent",
+  ];
+
+  public const string PROVIDE_METHOD_NAME = "this.Provide()";
+  public const string PROVIDE_NEW_METHOD_BODY = """
+// Call the this.Provide() method once your dependencies have been initialized.
+this.Provide();
+""";
+  public const string NOTIFY_METHOD_NAME = "this.Notify(what)";
+}

--- a/Chickensoft.AutoInject.Analyzers/src/utils/Diagnostics.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/utils/Diagnostics.cs
@@ -7,7 +7,7 @@ public static class Diagnostics {
   private const string ERR_CATEGORY = "Chickensoft.AutoInject.Analyzers";
 
   public static DiagnosticDescriptor MissingAutoInjectNotifyOverrideDescriptor { get; } = new(
-    id: $"{ERR_PREFIX}_001",
+    id: $"{ERR_PREFIX}001",
     title: $"Missing \"_Notification\" method override",
     messageFormat: $"Missing override of \"_Notification\" in AutoInject class implementation `{{0}}`",
     category: ERR_CATEGORY,
@@ -21,7 +21,7 @@ public static class Diagnostics {
   ) => Diagnostic.Create(MissingAutoInjectNotifyOverrideDescriptor, location, name);
 
   public static DiagnosticDescriptor MissingAutoInjectNotifyDescriptor { get; } = new(
-    id: $"{ERR_PREFIX}_002",
+    id: $"{ERR_PREFIX}002",
     title: $"Missing \"{Constants.NOTIFY_METHOD_NAME}\" method call",
     messageFormat: $"Missing \"{Constants.NOTIFY_METHOD_NAME}\" in AutoInject class implementation `{{0}}`",
     category: ERR_CATEGORY,
@@ -35,7 +35,7 @@ public static class Diagnostics {
   ) => Diagnostic.Create(MissingAutoInjectNotifyDescriptor, location, name);
 
   public static DiagnosticDescriptor MissingAutoInjectProvideDescriptor { get; } = new(
-    id: $"{ERR_PREFIX}_003",
+    id: $"{ERR_PREFIX}003",
     title: $"Missing \"{Constants.PROVIDE_METHOD_NAME}\" call in provider class",
     messageFormat: $"Missing \"{Constants.PROVIDE_METHOD_NAME}\" call in provider class implementation `{{0}}`",
     category: ERR_CATEGORY,

--- a/Chickensoft.AutoInject.Analyzers/src/utils/Diagnostics.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/utils/Diagnostics.cs
@@ -1,0 +1,50 @@
+namespace Chickensoft.AutoInject.Analyzers.Utils;
+
+using Microsoft.CodeAnalysis;
+
+public static class Diagnostics {
+  private const string ERR_PREFIX = "AUTO_INJECT";
+  private const string ERR_CATEGORY = "Chickensoft.AutoInject.Analyzers";
+
+  public static DiagnosticDescriptor MissingAutoInjectNotifyOverrideDescriptor { get; } = new(
+    id: $"{ERR_PREFIX}_001",
+    title: $"Missing \"_Notification\" method override",
+    messageFormat: $"Missing override of \"_Notification\" in AutoInject class implementation `{{0}}`",
+    category: ERR_CATEGORY,
+    defaultSeverity: DiagnosticSeverity.Error,
+    isEnabledByDefault: true,
+    description: "Overriding the _Notification method is required to pass the lifecycle of the Godot node to AutoInject. Without this, all AutoInject functionality will not work as expected."
+  );
+
+  public static Diagnostic MissingAutoInjectNotifyOverride(
+    Location location, string name
+  ) => Diagnostic.Create(MissingAutoInjectNotifyOverrideDescriptor, location, name);
+
+  public static DiagnosticDescriptor MissingAutoInjectNotifyDescriptor { get; } = new(
+    id: $"{ERR_PREFIX}_002",
+    title: $"Missing \"{Constants.NOTIFY_METHOD_NAME}\" method call",
+    messageFormat: $"Missing \"{Constants.NOTIFY_METHOD_NAME}\" in AutoInject class implementation `{{0}}`",
+    category: ERR_CATEGORY,
+    defaultSeverity: DiagnosticSeverity.Error,
+    isEnabledByDefault: true,
+    description: "Calling this.Notify(what); within the _Notification method is required to pass the lifecycle of the Godot node to AutoInject. Without this, all AutoInject functionality will not work as expected."
+  );
+
+  public static Diagnostic MissingAutoInjectNotify(
+    Location location, string name
+  ) => Diagnostic.Create(MissingAutoInjectNotifyDescriptor, location, name);
+
+  public static DiagnosticDescriptor MissingAutoInjectProvideDescriptor { get; } = new(
+    id: $"{ERR_PREFIX}_003",
+    title: $"Missing \"{Constants.PROVIDE_METHOD_NAME}\" call in provider class",
+    messageFormat: $"Missing \"{Constants.PROVIDE_METHOD_NAME}\" call in provider class implementation `{{0}}`",
+    category: ERR_CATEGORY,
+    defaultSeverity: DiagnosticSeverity.Error,
+    isEnabledByDefault: true,
+    description: "Calling the Provide method is required to provide dependencies to the AutoInject system. Without this, the provided dependencies will not be injected and dependent classes will not function as expected."
+  );
+
+  public static Diagnostic MissingAutoInjectProvide(
+    Location location, string name
+  ) => Diagnostic.Create(MissingAutoInjectProvideDescriptor, location, name);
+}

--- a/Chickensoft.AutoInject.Analyzers/src/utils/Diagnostics.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/utils/Diagnostics.cs
@@ -6,7 +6,7 @@ public static class Diagnostics {
   private const string ERR_PREFIX = "AUTO_INJECT";
   private const string ERR_CATEGORY = "Chickensoft.AutoInject.Analyzers";
 
-  public static DiagnosticDescriptor MissingAutoInjectNotifyOverrideDescriptor { get; } = new(
+  public static DiagnosticDescriptor MissingAutoInjectNotificationOverrideDescriptor { get; } = new(
     id: $"{ERR_PREFIX}001",
     title: $"Missing \"_Notification\" method override",
     messageFormat: $"Missing override of \"_Notification\" in AutoInject class implementation `{{0}}`",
@@ -16,9 +16,9 @@ public static class Diagnostics {
     description: "Overriding the _Notification method is required to pass the lifecycle of the Godot node to AutoInject. Without this, all AutoInject functionality will not work as expected."
   );
 
-  public static Diagnostic MissingAutoInjectNotifyOverride(
+  public static Diagnostic MissingAutoInjectNotificationOverride(
     Location location, string name
-  ) => Diagnostic.Create(MissingAutoInjectNotifyOverrideDescriptor, location, name);
+  ) => Diagnostic.Create(MissingAutoInjectNotificationOverrideDescriptor, location, name);
 
   public static DiagnosticDescriptor MissingAutoInjectNotifyDescriptor { get; } = new(
     id: $"{ERR_PREFIX}002",

--- a/Chickensoft.AutoInject.Analyzers/src/utils/MethodModifier.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/utils/MethodModifier.cs
@@ -1,0 +1,138 @@
+namespace Chickensoft.AutoInject.Analyzers.Utils;
+
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+using Microsoft.CodeAnalysis.Formatting;
+
+public static class MethodModifier {
+  /// <summary>
+  /// Adds a this.method call to the end of a specified method within a type declaration.
+  /// </summary>
+  /// <param name="document">Document to modify.</param>
+  /// <param name="typeDeclaration">Type declaration off the class.</param>
+  /// <param name="originalMethodNode">The method to add the call to.</param>
+  /// <param name="methodToCallName">Name of the method to call at the end of the target method.</param>
+  /// <param name="cancellationToken">Cancellation Token</param>
+  /// <returns>Modified document</returns>
+  public static async Task<Document> AddCallToMethod(Document document,
+    TypeDeclarationSyntax typeDeclaration,
+    MethodDeclarationSyntax originalMethodNode,
+    string methodToCallName,
+    CancellationToken cancellationToken)
+  {
+    // Construct the parameterless call statement
+    var parameterlessCallStatement = SyntaxFactory.ExpressionStatement(
+      SyntaxFactory.InvocationExpression(
+        SyntaxFactory.MemberAccessExpression(
+          SyntaxKind.SimpleMemberAccessExpression,
+          SyntaxFactory.ThisExpression(),
+          SyntaxFactory.IdentifierName(methodToCallName)))
+    ).WithAdditionalAnnotations(Formatter.Annotation);
+
+    // Delegate to the more general helper
+    return await AddStatementToMethodBodyAsync(
+      document,
+      typeDeclaration,
+      originalMethodNode,
+      parameterlessCallStatement,
+      cancellationToken
+    );
+  }
+
+  /// <summary>
+  /// Adds a provided statement to the end of a specified method's body within a type declaration.
+  /// Handles conversion from expression body to block body.
+  /// </summary>
+  /// <param name="document">Document to modify.</param>
+  /// <param name="typeDeclaration">Type declaration of the class.</param>
+  /// <param name="originalMethodNode">The method to add the statement to.</param>
+  /// <param name="statementToAdd">The pre-constructed statement to add.</param>
+  /// <param name="cancellationToken">Cancellation Token.</param>
+  /// <returns>Modified document.</returns>
+  public static async Task<Document> AddStatementToMethodBodyAsync(
+    Document document,
+    TypeDeclarationSyntax typeDeclaration,
+    MethodDeclarationSyntax originalMethodNode,
+    StatementSyntax statementToAdd,
+    CancellationToken cancellationToken)
+  {
+    var methodInProgress = originalMethodNode;
+    BlockSyntax finalNewBody;
+
+    if (originalMethodNode.Body is not null) // Existing block body
+    {
+        var existingStatements = originalMethodNode.Body.Statements;
+        var updatedStatements = existingStatements.Add(statementToAdd);
+        finalNewBody = originalMethodNode.Body.WithStatements(updatedStatements)
+                            .WithAdditionalAnnotations(Formatter.Annotation);
+    }
+    else // Expression body or missing body
+    {
+        var statementsForNewBlock = SyntaxFactory.List<StatementSyntax>();
+        if (originalMethodNode.ExpressionBody is not null)
+        {
+            var originalExpression = originalMethodNode.ExpressionBody.Expression;
+            var statementFromExpr = SyntaxFactory.ExpressionStatement(originalExpression);
+
+            // Make sure to preserve the trailing trivia from the original method's semicolon token
+            // If we don't do this we will lose any code comments or whitespace that was after the semicolon
+            var originalMethodSemicolon = originalMethodNode.SemicolonToken;
+            if (!originalMethodSemicolon.IsKind(SyntaxKind.None) && !originalMethodSemicolon.IsMissing)
+            {
+                var originalSemicolonTrailingTrivia = originalMethodSemicolon.TrailingTrivia;
+                if (originalSemicolonTrailingTrivia.Any())
+                {
+                    statementFromExpr = statementFromExpr.WithSemicolonToken(
+                        statementFromExpr.SemicolonToken.WithTrailingTrivia(originalSemicolonTrailingTrivia)
+                    );
+                }
+            }
+            statementFromExpr = statementFromExpr.WithAdditionalAnnotations(Formatter.Annotation);
+            statementsForNewBlock = statementsForNewBlock.Add(statementFromExpr);
+
+            // Remove the old expression body from the method
+            methodInProgress = methodInProgress
+                .WithExpressionBody(null)
+                .WithSemicolonToken(SyntaxFactory.MissingToken(SyntaxKind.SemicolonToken));
+        }
+
+        // Add the provided statement
+        statementsForNewBlock = statementsForNewBlock.Add(statementToAdd);
+        // Create a new block with the collected statements
+        finalNewBody = SyntaxFactory.Block(statementsForNewBlock)
+                            .WithAdditionalAnnotations(Formatter.Annotation);
+    }
+
+    // Ensure the method (methodInProgress) ends with a new line
+    // This is important when converting from an expression body to a block body
+    var trailingTrivia = methodInProgress.GetTrailingTrivia();
+    if (!trailingTrivia.Any() || !trailingTrivia.Last().IsKind(SyntaxKind.EndOfLineTrivia))
+    {
+      // Get the new line character from the document options
+      // This makes sure we use the same new line character as the rest of the document
+      var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
+      var newLineCharacter = documentOptions.GetOption(FormattingOptions.NewLine) ?? "\n";
+      var newLineTrivia = SyntaxFactory.EndOfLine(newLineCharacter);
+
+      // Add the newline
+      methodInProgress = methodInProgress.WithTrailingTrivia(trailingTrivia.Add(newLineTrivia));
+    }
+
+    var fullyModifiedMethod = methodInProgress.WithBody(finalNewBody);
+
+    // Replace the original method with the modified one in the type declaration
+    var newTypeDeclaration = typeDeclaration.ReplaceNode(originalMethodNode, fullyModifiedMethod);
+
+    var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
+    if (root is null)
+    {
+        return document;
+    }
+
+    var newRoot = root.ReplaceNode(typeDeclaration, newTypeDeclaration);
+    return document.WithSyntaxRoot(newRoot);
+  }
+}

--- a/Chickensoft.AutoInject.sln
+++ b/Chickensoft.AutoInject.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.AutoInject", "C
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.AutoInject.Tests", "Chickensoft.AutoInject.Tests\Chickensoft.AutoInject.Tests.csproj", "{9DD3D030-C9BE-42FE-B56F-8BC5FCF9579E}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Chickensoft.AutoInject.Analyzers", "Chickensoft.AutoInject.Analyzers\Chickensoft.AutoInject.Analyzers.csproj", "{70A5327C-5874-428E-BF51-C6854A1608F5}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -24,5 +26,9 @@ Global
 		{9DD3D030-C9BE-42FE-B56F-8BC5FCF9579E}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{9DD3D030-C9BE-42FE-B56F-8BC5FCF9579E}.Release|Any CPU.ActiveCfg = Debug|Any CPU
 		{9DD3D030-C9BE-42FE-B56F-8BC5FCF9579E}.Release|Any CPU.Build.0 = Debug|Any CPU
+		{70A5327C-5874-428E-BF51-C6854A1608F5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{70A5327C-5874-428E-BF51-C6854A1608F5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{70A5327C-5874-428E-BF51-C6854A1608F5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{70A5327C-5874-428E-BF51-C6854A1608F5}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 EndGlobal

--- a/README.md
+++ b/README.md
@@ -97,6 +97,14 @@ Simply add the following to your project's `.csproj` file. Be sure to specify th
 </ItemGroup>
 ```
 
+You can also add `Chickensoft.AutoInject.Analyzers` to your project to get additional checks and code fixes for AutoInject, such as ensuring that you override `_Notification` and call `this.Provide()` from your provider nodes.
+
+```xml
+<ItemGroup>
+    <PackageReference Include="Chickensoft.AutoInject.Analyzers" Version="..." PrivateAssets="all" OutputItemType="analyzer" />
+</ItemGroup>
+```
+
 > [!WARNING]
 > We strongly recommend treating warning `CS9057` as an error to catch possible compiler-mismatch issues with the Introspection generator. (See the [Introspection] README for more details.) To do so, add a `WarningsAsErrors` line to your `.csproj` file's `PropertyGroup`:
 >


### PR DESCRIPTION
This PR adds code analyzers and fixes for common mistakes when using AutoInject
- Forgetting to call `this.Notify`
- Forgetting to call `this.Provide`

This is my first time actually making something functional when it comes to Roslyn tools.

https://github.com/user-attachments/assets/4022761a-7530-4fab-8216-ab25f98501e9

## Analyzers

Three diagnostics are added:

- **`AUTO_INJECT_001` Missing "_Notification" method override**
Emitted when `_Notification` isn't overridden in any class that has any of the 6 AutoInject meta interfaces. 
- **`AUTO_INJECT_002` Missing "this.Notify(what)" method call**
Emitted when there is a `_Notification` method, but `this.Notify` isn't called within it.
- **`AUTO_INJECT_003` Missing "this.Provide()" call in provider class**
Emitted when a class has `IAutoNode` or `IProvider`, implements `IProvide<T>`, and doesn't have `this.Provide()` called anywhere in the class.

## Code Fixes

To help fix those issues, a handful of code fixes were added:

- **Add "this.Notify(what);" to existing \"_Notification\" override**
Does what it says really, it will also change expression syntax to block syntax if needed.
- **Add \"public override void _Notification(int what) => this.Notify(what);\" method**
Probably will be the most used, it directly adds that line to the top of the class.

Then for missing `this.Provide` calls we have a lot of options.

- `(if Setup() exists)` **Add "this.Provide();" to existing "Setup()" method**
	- `(else)` **Create "Setup()" method that calls "this.Provide();"**
- `(if OnReady() exists)` **Add "this.Provide();" to existing "OnReady()" method**
	- `(else)` **Create "OnReady()" method that calls "this.Provide();"**
- `(if _Ready()` exists) **Add "this.Provide();" to existing "_Ready()" method**
	- ~~I figured that a create `_Ready()` option wasn't needed because that's not really in the domain of AutoInject~~ **Edit:** Added a create option for this too
	
## Tests

I don't know how unit tests might be added for these, ~~feel free to add them for me~~. Just from testing it while making it, everything seems to work great, but it should be tested more.



## Issues

I don't know how to get this published as a NuGet package, I think I changed the appropriate values in the csproj but I don't know. Any help there would be appreciated.

The code fixes are in the same project as the analyzers, this might be a mistake? I had to silence [`RS1038`](https://github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1038.md) on the analyzers because of this, but I wasn't sure if I should split the code fixes into a new project or not, as it sounds like this warning can be worked around or doesn't apply to this according to https://github.com/dotnet/roslyn-analyzers/issues/7438

### Future

I want to add analyzers and code fixes for using `OnProcess` and `OnPhysicsProcess` without calling `SetPhysicsProcess(true);` or `SetProcess(true);`. Probably should go in a new PR though.