### PR TITLE
chore: fix release job to write analyzer version

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,8 +69,7 @@ jobs:
           find: "0.0.0-devbuild"
           replace: ${{ steps.next-version.outputs.version }}
           regex: false
-          include: Chickensoft.AutoInject/Chickensoft.AutoInject.csproj
-          include: Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
+          include: Chickensoft.AutoInject*/Chickensoft.AutoInject*.csproj
 
       - name: 🖨 Copy Source to Source-Only package
         run: |


### PR DESCRIPTION
The gha-find-replace action allows only one include with a glob pattern. Updated the release workflow job for writing the new version to have a single include with a glob that matches all csproj files. This will include the test csproj, but it doesn't have the magic string for writing the version number, so that shouldn't matter.