### PR TITLE
chore: add rulers in vscode

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,6 +14,7 @@
   "dotnet.defaultSolution": "Chickensoft.AutoInject.sln",
   "csharp.semanticHighlighting.enabled": true,
   "editor.semanticHighlighting.enabled": true,
+  "editor.rulers": [80, 120],
   // C# doc comment colorization gets lost with semantic highlighting, but we
   // need semantic highlighting for proper syntax highlighting with record
   // shorthand.


### PR DESCRIPTION
Added rulers at 80, 120 characters to make it easier to observe Chickensoft style.