### PR TITLE
chore: use lf as editorconfig default eol

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -46,6 +46,7 @@ indent_style = space
 indent_size = 2
 insert_final_newline = true
 trim_trailing_whitespace = true
+end_of_line = lf
 
 ##########################################
 # File Extension Settings


### PR DESCRIPTION
Updated editorconfig to use lf as the default end-of-line for all files unless otherwise specified.