### PR TITLE
fix: ignore generated source code in Analyzers

### DIFF
--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotificationOverrideMissingAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotificationOverrideMissingAnalyzer.cs
@@ -18,8 +18,7 @@ public class AutoInjectNotificationOverrideMissingAnalyzer : DiagnosticAnalyzer 
     context.EnableConcurrentExecution();
 
     context.ConfigureGeneratedCodeAnalysis(
-      GeneratedCodeAnalysisFlags.Analyze |
-      GeneratedCodeAnalysisFlags.ReportDiagnostics
+      GeneratedCodeAnalysisFlags.None
     );
 
     context.RegisterSyntaxNodeAction(

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyMissingAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyMissingAnalyzer.cs
@@ -18,8 +18,7 @@ public class AutoInjectNotifyMissingAnalyzer : DiagnosticAnalyzer {
     context.EnableConcurrentExecution();
 
     context.ConfigureGeneratedCodeAnalysis(
-      GeneratedCodeAnalysisFlags.Analyze |
-      GeneratedCodeAnalysisFlags.ReportDiagnostics
+      GeneratedCodeAnalysisFlags.None
     );
 
     context.RegisterSyntaxNodeAction(

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
@@ -22,8 +22,7 @@ public class AutoInjectProvideAnalyzer : DiagnosticAnalyzer {
     context.EnableConcurrentExecution();
 
     context.ConfigureGeneratedCodeAnalysis(
-      GeneratedCodeAnalysisFlags.Analyze |
-      GeneratedCodeAnalysisFlags.ReportDiagnostics
+      GeneratedCodeAnalysisFlags.None
     );
 
     context.RegisterSyntaxNodeAction(


### PR DESCRIPTION
Not running analyzers against generated source code seems to improve performance somewhat, and shouldn't be necessary. (See #53.)