### PR TITLE
perf: avoid allocating identical arrays for every analyzer

### DIFF
--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotificationOverrideMissingAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotificationOverrideMissingAnalyzer.cs
@@ -10,9 +10,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AutoInjectNotificationOverrideMissingAnalyzer : DiagnosticAnalyzer {
-  public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics {
-    get;
-  } = [Diagnostics.MissingAutoInjectNotificationOverrideDescriptor];
+  private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
+    [Diagnostics.MissingAutoInjectNotificationOverrideDescriptor];
+
+  public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+    _supportedDiagnostics;
 
   public override void Initialize(AnalysisContext context) {
     context.EnableConcurrentExecution();

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyMissingAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyMissingAnalyzer.cs
@@ -10,9 +10,11 @@ using Microsoft.CodeAnalysis.Diagnostics;
 
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AutoInjectNotifyMissingAnalyzer : DiagnosticAnalyzer {
-  public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics {
-    get;
-  } = [Diagnostics.MissingAutoInjectNotifyDescriptor];
+  private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
+    [Diagnostics.MissingAutoInjectNotifyDescriptor];
+
+  public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+    _supportedDiagnostics;
 
   public override void Initialize(AnalysisContext context) {
     context.EnableConcurrentExecution();

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
@@ -14,9 +14,11 @@ using Utils;
 /// </summary>
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
 public class AutoInjectProvideAnalyzer : DiagnosticAnalyzer {
-  public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics {
-    get;
-  } = [Diagnostics.MissingAutoInjectProvideDescriptor];
+  private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
+    [Diagnostics.MissingAutoInjectProvideDescriptor];
+
+  public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics =>
+    _supportedDiagnostics;
 
   public override void Initialize(AnalysisContext context) {
     context.EnableConcurrentExecution();

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotificationOverrideFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotificationOverrideFixProvider.cs
@@ -22,8 +22,11 @@ using Utils;
   Shared
 ]
 public class AutoInjectNotificationOverrideFixProvider : CodeFixProvider {
-  public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+  private static readonly ImmutableArray<string> _fixableDiagnosticIds =
     [Diagnostics.MissingAutoInjectNotificationOverrideDescriptor.Id];
+
+  public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+    _fixableDiagnosticIds;
 
   public sealed override FixAllProvider GetFixAllProvider() =>
     WellKnownFixAllProviders.BatchFixer;

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
@@ -21,8 +21,11 @@ using Utils;
   Shared
 ]
 public class AutoInjectNotifyMissingFixProvider : CodeFixProvider {
-  public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+  private static readonly ImmutableArray<string> _fixableDiagnosticIds =
     [Diagnostics.MissingAutoInjectNotifyDescriptor.Id];
+
+  public sealed override ImmutableArray<string> FixableDiagnosticIds =>
+    _fixableDiagnosticIds;
 
   public sealed override FixAllProvider GetFixAllProvider() =>
     WellKnownFixAllProviders.BatchFixer;

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectProvideFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectProvideFixProvider.cs
@@ -19,12 +19,15 @@ using Utils;
 [ExportCodeFixProvider(LanguageNames.CSharp, Name = nameof(AutoInjectProvideFixProvider))]
 [Shared]
 public class AutoInjectProvideFixProvider : CodeFixProvider {
+  private static readonly ImmutableArray<string> _fixableDiagnosticIds =
+    [Diagnostics.MissingAutoInjectProvideDescriptor.Id];
+
   public const string SETUP_METHOD_NAME = "Setup";
   public const string ONREADY_METHOD_NAME = "OnReady";
   public const string READY_OVERRIDE_METHOD_NAME = "_Ready";
 
   public sealed override ImmutableArray<string> FixableDiagnosticIds =>
-    [Diagnostics.MissingAutoInjectProvideDescriptor.Id];
+    _fixableDiagnosticIds;
 
   public sealed override FixAllProvider GetFixAllProvider() =>
     WellKnownFixAllProviders.BatchFixer;


### PR DESCRIPTION
Use static ImmutableArrays for analyzer/provider diagnostic codes, since they are per-type, not per-instance. With this change, if multiple copies of an analyzer or provider are instantiated, we avoid allocating separate but identical ImmutableArrays for every instance.