### PR TITLE
test: new code-fix tests

### DIFF
--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotificationOverrideMissingAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotificationOverrideMissingAnalyzer.cs
@@ -32,35 +32,26 @@ public class AutoInjectNotificationOverrideMissingAnalyzer : DiagnosticAnalyzer 
   private static void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context) {
     var classDeclaration = (ClassDeclarationSyntax)context.Node;
 
-    var attributes = classDeclaration.AttributeLists.SelectMany(list => list.Attributes
-    ).Where(attribute => attribute.Name.ToString() == Constants.META_ATTRIBUTE_NAME
-       // Check that Meta attribute has an AutoInject type (ex: [Meta(typeof(IAutoNode))])
-       && attribute.ArgumentList?.Arguments.Any(arg =>
-          arg.Expression is TypeOfExpressionSyntax { Type: IdentifierNameSyntax identifierName } &&
-         Constants.AutoInjectTypeNames.Contains(identifierName.Identifier.ValueText)
-       ) == true
-    )
-    .ToList();
+    var attribute = AnalyzerTools.GetAutoInjectMetaAttribute(
+      classDeclaration,
+      Constants.AutoInjectMetaNames.Contains
+    );
 
-    if (attributes.Count == 0) {
+    if (attribute is null) {
       return;
     }
 
     // Check if the class has a _Notification override method.
-    var hasNotificationOverride = classDeclaration
-      .Members
-      .OfType<MethodDeclarationSyntax>()
-      .Any(method =>
-        method.Identifier.ValueText == "_Notification" &&
-        method.Modifiers.Any(SyntaxKind.OverrideKeyword) &&
-        method.ParameterList.Parameters.Count == 1
-      );
+    var notificationOverride = AnalyzerTools.GetMethodOverride(
+      classDeclaration,
+      Constants.NOTIFICATION_METHOD_NAME
+    );
 
-    if (!hasNotificationOverride) {
-      // Report missing Notify call, _Notification override already exists.
+    if (notificationOverride is null) {
+      // Report missing _Notification override.
       context.ReportDiagnostic(
         Diagnostics.MissingAutoInjectNotificationOverride(
-          attributes[0].GetLocation(),
+          attribute.GetLocation(),
           classDeclaration.Identifier.ValueText
         )
       );

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyMissingAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyMissingAnalyzer.cs
@@ -32,49 +32,34 @@ public class AutoInjectNotifyMissingAnalyzer : DiagnosticAnalyzer {
   private static void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context) {
     var classDeclaration = (ClassDeclarationSyntax)context.Node;
 
-    var attributes = classDeclaration.AttributeLists.SelectMany(list => list.Attributes
-    ).Where(attribute => attribute.Name.ToString() == Constants.META_ATTRIBUTE_NAME
-       // Check that Meta attribute has an AutoInject type (ex: [Meta(typeof(IAutoNode))])
-       && attribute.ArgumentList?.Arguments.Any(arg =>
-          arg.Expression is TypeOfExpressionSyntax { Type: IdentifierNameSyntax identifierName } &&
-         Constants.AutoInjectTypeNames.Contains(identifierName.Identifier.ValueText)
-       ) == true
-    )
-    .ToList();
+    var attribute = AnalyzerTools.GetAutoInjectMetaAttribute(
+      classDeclaration,
+      Constants.AutoInjectMetaNames.Contains
+    );
 
-    if (attributes.Count == 0) {
+    if (attribute is null) {
       return;
     }
 
     // Check if the class has a _Notification override method.
     // If it doesn't, the NotificationOverrideMissing analyzer will get it.
-    var hasNotificationOverride = classDeclaration
-      .Members
-      .OfType<MethodDeclarationSyntax>()
-      .Any(
-        method =>
-          method.Identifier.ValueText == "_Notification"
-            && method.Modifiers.Any(SyntaxKind.OverrideKeyword)
-            && method.ParameterList.Parameters.Count == 1
+    var notificationOverride = AnalyzerTools.GetMethodOverride(
+      classDeclaration,
+      Constants.NOTIFICATION_METHOD_NAME
+    );
+
+    if (notificationOverride is not null) {
+      // Check if the class calls "this.Notify()" in the _Notification override.
+      var hasNotify = AnalyzerTools.HasThisCall(
+        notificationOverride,
+        Constants.NOTIFY_METHOD_NAME
       );
 
-    if (hasNotificationOverride) {
-      // Check if the class calls "this.Notify()" in the _Notification override.
-      var hasNotify = classDeclaration
-        .DescendantNodes()
-        .OfType<InvocationExpressionSyntax>()
-        .Any(invocation =>
-          invocation.Expression is MemberAccessExpressionSyntax {
-            Name.Identifier.ValueText: "Notify",
-            Expression: ThisExpressionSyntax
-          }
-        );
-
       if (!hasNotify) {
-        // Report missing Notify call, _Notification override does not exist.
+        // Report missing Notify call
         context.ReportDiagnostic(
           Diagnostics.MissingAutoInjectNotify(
-            attributes[0].GetLocation(),
+            attribute.GetLocation(),
             classDeclaration.Identifier.ValueText
           )
         );

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectNotifyMissingFixProvider.cs
@@ -131,7 +131,6 @@ public class AutoInjectNotifyMissingFixProvider : CodeFixProvider {
     // Add the statement to the method body
     return await MethodModifier.AddStatementToMethodBodyAsync(
         document,
-        typeDeclaration,
         originalMethodNode,
         statementToAdd,
         cancellationToken

--- a/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectProvideFixProvider.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/fixes/AutoInjectProvideFixProvider.cs
@@ -133,7 +133,6 @@ public class AutoInjectProvideFixProvider : CodeFixProvider {
           createChangedDocument: c =>
             MethodModifier.AddCallToMethod(
               context.Document,
-              typeDeclaration,
               existingMethod,
               "Provide",
               c

--- a/Chickensoft.AutoInject.Analyzers/src/utils/AnalyzerTools.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/utils/AnalyzerTools.cs
@@ -1,0 +1,58 @@
+namespace Chickensoft.AutoInject.Analyzers.Utils;
+
+using System;
+using System.Linq;
+using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.CSharp;
+using Microsoft.CodeAnalysis.CSharp.Syntax;
+
+public static class AnalyzerTools {
+  public static AttributeSyntax? GetAutoInjectMetaAttribute(
+    ClassDeclarationSyntax classDeclaration,
+    Func<string, bool> isMetaName
+  ) =>
+    classDeclaration.
+      AttributeLists
+      .SelectMany(list => list.Attributes)
+      .FirstOrDefault(
+        attr =>
+          attr.ArgumentList is not null
+            && attr.Name.ToString() == Constants.META_ATTRIBUTE_NAME
+            && attr.ArgumentList.Arguments.Any(
+              arg =>
+                arg.Expression is TypeOfExpressionSyntax {
+                  Type: IdentifierNameSyntax identifierName
+                }
+                  && isMetaName(identifierName.Identifier.ValueText)
+            )
+      );
+
+  public static MethodDeclarationSyntax? GetMethodOverride(
+    TypeDeclarationSyntax typeDeclaration,
+    string methodName
+  ) =>
+    typeDeclaration
+      .Members
+      .OfType<MethodDeclarationSyntax>()
+      .FirstOrDefault(
+        method =>
+          method.ParameterList.Parameters.Count == 1
+            && method.Identifier.ValueText == methodName
+            && method.Modifiers.Any(SyntaxKind.OverrideKeyword)
+      );
+
+  public static bool HasThisCall(
+    MemberDeclarationSyntax node,
+    string methodName
+  ) =>
+    node
+      .DescendantNodes()
+      .OfType<InvocationExpressionSyntax>()
+      .Any(
+        invocation =>
+          invocation.Expression is MemberAccessExpressionSyntax {
+            Expression: ThisExpressionSyntax
+          } memberInvocation
+            && memberInvocation.Name.Identifier.ValueText == methodName
+      );
+}

--- a/Chickensoft.AutoInject.Analyzers/src/utils/Constants.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/utils/Constants.cs
@@ -2,21 +2,25 @@ namespace Chickensoft.AutoInject.Analyzers.Utils;
 
 public static class Constants {
   public const string META_ATTRIBUTE_NAME = "Meta";
-
-  /// <summary>
-  /// Type names that we look for in Meta attributes to determine if a class needs a this.Provide() call.
-  /// </summary>
-  public static readonly string[] ProviderMetaNames = [
-    "IAutoNode",
-    "IProvider",
-  ];
-
+  public const string PROVIDE_METHOD_NAME = "Provide";
+  public const string NOTIFY_METHOD_NAME = "Notify";
+  public const string NOTIFICATION_METHOD_NAME = "_Notification";
+  public const string SETUP_METHOD_NAME = "Setup";
+  public const string ONREADY_METHOD_NAME = "OnReady";
+  public const string READY_METHOD_NAME = "_Ready";
+  public const string WHAT_PARAMETER_NAME = "what";
   public const string PROVIDER_INTERFACE_NAME = "IProvide";
+  public const string MESSAGE_PROVIDE_METHOD_NAME = "this.Provide()";
+  public const string PROVIDE_NEW_METHOD_BODY = """
+// Call the this.Provide() method once your dependencies have been initialized.
+this.Provide();
+""";
+  public const string MESSAGE_NOTIFY_METHOD_NAME = "this.Notify(what)";
 
   /// <summary>
   /// Type names that we look for in Meta attributes to determine if a class needs a this.Notify(what) call.
   /// </summary>
-  public static readonly string[] AutoInjectTypeNames = [
+  public static string[] AutoInjectMetaNames = [
     "IAutoNode",
     "IAutoOn",
     "IAutoConnect",
@@ -25,10 +29,11 @@ public static class Constants {
     "IDependent",
   ];
 
-  public const string PROVIDE_METHOD_NAME = "this.Provide()";
-  public const string PROVIDE_NEW_METHOD_BODY = """
-// Call the this.Provide() method once your dependencies have been initialized.
-this.Provide();
-""";
-  public const string NOTIFY_METHOD_NAME = "this.Notify(what)";
+  /// <summary>
+  /// Type names that we look for in Meta attributes to determine if a class needs a this.Provide() call.
+  /// </summary>
+  public static string[] ProviderMetaNames = [
+    "IAutoNode",
+    "IProvider",
+  ];
 }

--- a/Chickensoft.AutoInject.Analyzers/src/utils/MethodModifier.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/utils/MethodModifier.cs
@@ -9,20 +9,23 @@ using Microsoft.CodeAnalysis.Formatting;
 
 public static class MethodModifier {
   /// <summary>
-  /// Adds a this.method call to the end of a specified method within a type declaration.
+  /// Adds a this.method call to the end of a specified method within a type
+  /// declaration.
   /// </summary>
   /// <param name="document">Document to modify.</param>
   /// <param name="typeDeclaration">Type declaration off the class.</param>
   /// <param name="originalMethodNode">The method to add the call to.</param>
-  /// <param name="methodToCallName">Name of the method to call at the end of the target method.</param>
+  /// <param name="methodToCallName">
+  /// Name of the method to call at the end of the target method.
+  /// </param>
   /// <param name="cancellationToken">Cancellation Token</param>
   /// <returns>Modified document</returns>
-  public static async Task<Document> AddCallToMethod(Document document,
-    TypeDeclarationSyntax typeDeclaration,
+  public static async Task<Document> AddCallToMethod(
+    Document document,
     MethodDeclarationSyntax originalMethodNode,
     string methodToCallName,
-    CancellationToken cancellationToken)
-  {
+    CancellationToken cancellationToken
+  ) {
     // Construct the parameterless call statement
     var parameterlessCallStatement = SyntaxFactory.ExpressionStatement(
       SyntaxFactory.InvocationExpression(
@@ -35,7 +38,6 @@ public static class MethodModifier {
     // Delegate to the more general helper
     return await AddStatementToMethodBodyAsync(
       document,
-      typeDeclaration,
       originalMethodNode,
       parameterlessCallStatement,
       cancellationToken
@@ -43,96 +45,87 @@ public static class MethodModifier {
   }
 
   /// <summary>
-  /// Adds a provided statement to the end of a specified method's body within a type declaration.
-  /// Handles conversion from expression body to block body.
+  /// Adds a provided statement to the end of a specified method's body within a
+  /// type declaration. Handles conversion from expression body to block body.
   /// </summary>
   /// <param name="document">Document to modify.</param>
   /// <param name="typeDeclaration">Type declaration of the class.</param>
-  /// <param name="originalMethodNode">The method to add the statement to.</param>
+  /// <param name="originalMethodNode">
+  /// The method to add the statement to.
+  /// </param>
   /// <param name="statementToAdd">The pre-constructed statement to add.</param>
   /// <param name="cancellationToken">Cancellation Token.</param>
   /// <returns>Modified document.</returns>
   public static async Task<Document> AddStatementToMethodBodyAsync(
     Document document,
-    TypeDeclarationSyntax typeDeclaration,
     MethodDeclarationSyntax originalMethodNode,
     StatementSyntax statementToAdd,
-    CancellationToken cancellationToken)
-  {
+    CancellationToken cancellationToken
+  ) {
+    var root = await document
+      .GetSyntaxRootAsync(cancellationToken)
+      .ConfigureAwait(false);
+
+    if (root is null) {
+      return document;
+    }
+
     var methodInProgress = originalMethodNode;
     BlockSyntax finalNewBody;
 
-    if (originalMethodNode.Body is not null) // Existing block body
-    {
-        var existingStatements = originalMethodNode.Body.Statements;
-        var updatedStatements = existingStatements.Add(statementToAdd);
-        finalNewBody = originalMethodNode.Body.WithStatements(updatedStatements)
-                            .WithAdditionalAnnotations(Formatter.Annotation);
+    if (originalMethodNode.Body is not null) {
+      // Existing block body
+      var existingStatements = originalMethodNode.Body.Statements;
+      var updatedStatements = existingStatements.Add(statementToAdd);
+      finalNewBody = originalMethodNode.Body.WithStatements(updatedStatements);
     }
-    else // Expression body or missing body
-    {
-        var statementsForNewBlock = SyntaxFactory.List<StatementSyntax>();
-        if (originalMethodNode.ExpressionBody is not null)
-        {
-            var originalExpression = originalMethodNode.ExpressionBody.Expression;
-            var statementFromExpr = SyntaxFactory.ExpressionStatement(originalExpression);
+    else {
+      // Expression body or missing body
+      var statementsForNewBlock = SyntaxFactory.List<StatementSyntax>();
+      if (originalMethodNode.ExpressionBody is not null) {
+        var originalExpression = originalMethodNode.ExpressionBody.Expression;
+        var statementFromExpr = SyntaxFactory
+          .ExpressionStatement(originalExpression);
 
-            // Make sure to preserve the trailing trivia from the original method's semicolon token
-            // If we don't do this we will lose any code comments or whitespace that was after the semicolon
-            var originalMethodSemicolon = originalMethodNode.SemicolonToken;
-            if (!originalMethodSemicolon.IsKind(SyntaxKind.None) && !originalMethodSemicolon.IsMissing)
-            {
-                var originalSemicolonTrailingTrivia = originalMethodSemicolon.TrailingTrivia;
-                if (originalSemicolonTrailingTrivia.Any())
-                {
-                    statementFromExpr = statementFromExpr.WithSemicolonToken(
-                        statementFromExpr.SemicolonToken.WithTrailingTrivia(originalSemicolonTrailingTrivia)
-                    );
-                }
-            }
-            statementFromExpr = statementFromExpr.WithAdditionalAnnotations(Formatter.Annotation);
-            statementsForNewBlock = statementsForNewBlock.Add(statementFromExpr);
-
-            // Remove the old expression body from the method
-            methodInProgress = methodInProgress
-                .WithExpressionBody(null)
-                .WithSemicolonToken(SyntaxFactory.MissingToken(SyntaxKind.SemicolonToken));
+        // Make sure to preserve the trailing trivia from the original method's semicolon token
+        // If we don't do this we will lose any code comments or whitespace that was after the semicolon
+        var originalMethodSemicolon = originalMethodNode.SemicolonToken;
+        if (
+          !originalMethodSemicolon.IsKind(SyntaxKind.None)
+            && !originalMethodSemicolon.IsMissing
+        ) {
+          var originalSemicolonTrailingTrivia = originalMethodSemicolon
+            .TrailingTrivia;
+          if (originalSemicolonTrailingTrivia.Any()) {
+            statementFromExpr = statementFromExpr
+              .WithSemicolonToken(
+                statementFromExpr
+                  .SemicolonToken
+                  .WithTrailingTrivia(originalSemicolonTrailingTrivia)
+              );
+          }
         }
+        statementsForNewBlock = statementsForNewBlock.Add(statementFromExpr);
 
-        // Add the provided statement
-        statementsForNewBlock = statementsForNewBlock.Add(statementToAdd);
-        // Create a new block with the collected statements
-        finalNewBody = SyntaxFactory.Block(statementsForNewBlock)
-                            .WithAdditionalAnnotations(Formatter.Annotation);
+        // Remove the old expression body from the method
+        methodInProgress = methodInProgress
+            .WithExpressionBody(null)
+            .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.None));
+      }
+
+      // Add the provided statement
+      statementsForNewBlock = statementsForNewBlock.Add(statementToAdd);
+      // Create a new block with the collected statements
+      finalNewBody = SyntaxFactory
+        .Block(statementsForNewBlock);
     }
 
-    // Ensure the method (methodInProgress) ends with a new line
-    // This is important when converting from an expression body to a block body
-    var trailingTrivia = methodInProgress.GetTrailingTrivia();
-    if (!trailingTrivia.Any() || !trailingTrivia.Last().IsKind(SyntaxKind.EndOfLineTrivia))
-    {
-      // Get the new line character from the document options
-      // This makes sure we use the same new line character as the rest of the document
-      var documentOptions = await document.GetOptionsAsync(cancellationToken).ConfigureAwait(false);
-      var newLineCharacter = documentOptions.GetOption(FormattingOptions.NewLine) ?? "\n";
-      var newLineTrivia = SyntaxFactory.EndOfLine(newLineCharacter);
-
-      // Add the newline
-      methodInProgress = methodInProgress.WithTrailingTrivia(trailingTrivia.Add(newLineTrivia));
-    }
-
-    var fullyModifiedMethod = methodInProgress.WithBody(finalNewBody);
+    var fullyModifiedMethod = methodInProgress
+      .WithBody(finalNewBody)
+      .WithAdditionalAnnotations(Formatter.Annotation);
 
     // Replace the original method with the modified one in the type declaration
-    var newTypeDeclaration = typeDeclaration.ReplaceNode(originalMethodNode, fullyModifiedMethod);
-
-    var root = await document.GetSyntaxRootAsync(cancellationToken).ConfigureAwait(false);
-    if (root is null)
-    {
-        return document;
-    }
-
-    var newRoot = root.ReplaceNode(typeDeclaration, newTypeDeclaration);
+    var newRoot = root.ReplaceNode(originalMethodNode, fullyModifiedMethod);
     return document.WithSyntaxRoot(newRoot);
   }
 }


### PR DESCRIPTION
Added new tests for code fixes that add and update methods for `this.Provide()`. When replacing expression body with block body, replaced `MissingToken` for semicolon with `None` token to resolve test failures.

Also did some DRY refactoring for the analyzers.