### PR TITLE
perf: use DocumentEditor in code fixes

### DIFF
--- a/Chickensoft.AutoInject.Analyzers.PerformanceTests/test/src/fixes/NotificationFixBenchmark.cs
+++ b/Chickensoft.AutoInject.Analyzers.PerformanceTests/test/src/fixes/NotificationFixBenchmark.cs
@@ -119,8 +119,10 @@ public class NotificationFixBenchmark {
         CancellationToken.None
       );
       var action = await fixAllProvider.GetFixAsync(fixAllContext).ConfigureAwait(false);
-      var operations = await action!.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
-      var solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
+      if (action is not null) {
+        var operations = await action!.GetOperationsAsync(CancellationToken.None).ConfigureAwait(false);
+        var solution = operations.OfType<ApplyChangesOperation>().Single().ChangedSolution;
+      }
     }
   }
 }

--- a/Chickensoft.AutoInject.Analyzers.PerformanceTests/test/src/fixes/ProvideFixExistingMethodsBenchmark.cs
+++ b/Chickensoft.AutoInject.Analyzers.PerformanceTests/test/src/fixes/ProvideFixExistingMethodsBenchmark.cs
@@ -117,7 +117,7 @@ public class ProvideFixExistingMethodsBenchmark {
         codeFixProvider,
         FixAllScope.Document,
         AutoInjectProvideFixProvider.GetCodeFixEquivalenceKey(
-          AutoInjectProvideFixProvider.SETUP_METHOD_NAME,
+          Analyzers.Utils.Constants.SETUP_METHOD_NAME,
           true
         ),
         fixAllProvider.GetSupportedFixAllDiagnosticIds(codeFixProvider),
@@ -158,7 +158,7 @@ public class ProvideFixExistingMethodsBenchmark {
         codeFixProvider,
         FixAllScope.Document,
         AutoInjectProvideFixProvider.GetCodeFixEquivalenceKey(
-          AutoInjectProvideFixProvider.ONREADY_METHOD_NAME,
+          Analyzers.Utils.Constants.ONREADY_METHOD_NAME,
           true
         ),
         fixAllProvider.GetSupportedFixAllDiagnosticIds(codeFixProvider),
@@ -199,7 +199,7 @@ public class ProvideFixExistingMethodsBenchmark {
         codeFixProvider,
         FixAllScope.Document,
         AutoInjectProvideFixProvider.GetCodeFixEquivalenceKey(
-          AutoInjectProvideFixProvider.READY_OVERRIDE_METHOD_NAME,
+          Analyzers.Utils.Constants.READY_METHOD_NAME,
           true
         ),
         fixAllProvider.GetSupportedFixAllDiagnosticIds(codeFixProvider),

--- a/Chickensoft.AutoInject.Analyzers.PerformanceTests/test/src/fixes/ProvideFixNewMethodsBenchmark.cs
+++ b/Chickensoft.AutoInject.Analyzers.PerformanceTests/test/src/fixes/ProvideFixNewMethodsBenchmark.cs
@@ -115,7 +115,7 @@ public class ProvideFixNewMethodsBenchmark {
         codeFixProvider,
         FixAllScope.Document,
         AutoInjectProvideFixProvider.GetCodeFixEquivalenceKey(
-          AutoInjectProvideFixProvider.SETUP_METHOD_NAME,
+          Analyzers.Utils.Constants.SETUP_METHOD_NAME,
           false
         ),
         fixAllProvider.GetSupportedFixAllDiagnosticIds(codeFixProvider),
@@ -156,7 +156,7 @@ public class ProvideFixNewMethodsBenchmark {
         codeFixProvider,
         FixAllScope.Document,
         AutoInjectProvideFixProvider.GetCodeFixEquivalenceKey(
-          AutoInjectProvideFixProvider.ONREADY_METHOD_NAME,
+          Analyzers.Utils.Constants.ONREADY_METHOD_NAME,
           false
         ),
         fixAllProvider.GetSupportedFixAllDiagnosticIds(codeFixProvider),
@@ -197,7 +197,7 @@ public class ProvideFixNewMethodsBenchmark {
         codeFixProvider,
         FixAllScope.Document,
         AutoInjectProvideFixProvider.GetCodeFixEquivalenceKey(
-          AutoInjectProvideFixProvider.READY_OVERRIDE_METHOD_NAME,
+          Analyzers.Utils.Constants.READY_METHOD_NAME,
           false
         ),
         fixAllProvider.GetSupportedFixAllDiagnosticIds(codeFixProvider),

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
@@ -33,7 +33,7 @@ public class AutoInjectProvideAnalyzer : DiagnosticAnalyzer {
     );
   }
 
-  private void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context) {
+  private static void AnalyzeClassDeclaration(SyntaxNodeAnalysisContext context) {
     var classDeclaration = (ClassDeclarationSyntax)context.Node;
 
     if (classDeclaration.BaseList is null) {

--- a/Chickensoft.AutoInject.Analyzers/src/utils/MethodModifier.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/utils/MethodModifier.cs
@@ -1,48 +1,68 @@
 namespace Chickensoft.AutoInject.Analyzers.Utils;
 
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using Microsoft.CodeAnalysis.Formatting;
+using Microsoft.CodeAnalysis.Editing;
 
 public static class MethodModifier {
   /// <summary>
-  /// Adds a this.method call to the end of a specified method within a type
-  /// declaration.
+  /// Creates a this.method call expression syntax node for the given method
+  /// name.
   /// </summary>
-  /// <param name="document">Document to modify.</param>
-  /// <param name="typeDeclaration">Type declaration off the class.</param>
-  /// <param name="originalMethodNode">The method to add the call to.</param>
   /// <param name="methodToCallName">
-  /// Name of the method to call at the end of the target method.
+  /// The name of the member method to call.
   /// </param>
-  /// <param name="cancellationToken">Cancellation Token</param>
-  /// <returns>Modified document</returns>
-  public static async Task<Document> AddCallToMethod(
-    Document document,
-    MethodDeclarationSyntax originalMethodNode,
+  /// <returns>
+  /// An expression node representing a "this.method()" expression.
+  /// </returns>
+  public static InvocationExpressionSyntax ThisMemberCallExpression(
     string methodToCallName,
-    CancellationToken cancellationToken
+    IEnumerable<string> argumentNames
   ) {
-    // Construct the parameterless call statement
-    var parameterlessCallStatement = SyntaxFactory.ExpressionStatement(
-      SyntaxFactory.InvocationExpression(
+    var invocation = SyntaxFactory.InvocationExpression(
         SyntaxFactory.MemberAccessExpression(
           SyntaxKind.SimpleMemberAccessExpression,
           SyntaxFactory.ThisExpression(),
-          SyntaxFactory.IdentifierName(methodToCallName)))
-    ).WithAdditionalAnnotations(Formatter.Annotation);
-
-    // Delegate to the more general helper
-    return await AddStatementToMethodBodyAsync(
-      document,
-      originalMethodNode,
-      parameterlessCallStatement,
-      cancellationToken
+          SyntaxFactory.IdentifierName(methodToCallName)
+        )
     );
+    if (argumentNames.Any()) {
+      invocation = invocation.WithArgumentList(
+        SyntaxFactory.ArgumentList(
+          SyntaxFactory.SeparatedList(
+            argumentNames.Select(
+              name =>
+                SyntaxFactory.Argument(SyntaxFactory.IdentifierName(name))
+            )
+          )
+        )
+      );
+    }
+    return invocation;
   }
+
+  /// <summary>
+  /// Creates a this.method call statement syntax node for the given method
+  /// name.
+  /// </summary>
+  /// <param name="methodToCallName">
+  /// The name of the member method to call.
+  /// </param>
+  /// <returns>
+  /// An expression statement node representing a "this.method()" statement.
+  /// </returns>
+  public static ExpressionStatementSyntax ThisMemberCallStatement(
+    string methodToCallName,
+    IEnumerable<string> argumentNames
+  ) =>
+    SyntaxFactory.ExpressionStatement(
+      ThisMemberCallExpression(methodToCallName, argumentNames)
+    );
 
   /// <summary>
   /// Adds a provided statement to the end of a specified method's body within a
@@ -62,31 +82,16 @@ public static class MethodModifier {
     StatementSyntax statementToAdd,
     CancellationToken cancellationToken
   ) {
-    var root = await document
-      .GetSyntaxRootAsync(cancellationToken)
-      .ConfigureAwait(false);
+    var editor = await DocumentEditor.CreateAsync(document, cancellationToken);
 
-    if (root is null) {
-      return document;
-    }
-
-    var methodInProgress = originalMethodNode;
-    BlockSyntax finalNewBody;
-
+    List<SyntaxNode> statements = [];
     if (originalMethodNode.Body is not null) {
-      // Existing block body
-      var existingStatements = originalMethodNode.Body.Statements;
-      var updatedStatements = existingStatements.Add(statementToAdd);
-      finalNewBody = originalMethodNode.Body.WithStatements(updatedStatements);
+      statements.AddRange(editor.Generator.GetStatements(originalMethodNode));
     }
     else {
-      // Expression body or missing body
-      var statementsForNewBlock = SyntaxFactory.List<StatementSyntax>();
-      if (originalMethodNode.ExpressionBody is not null) {
-        var originalExpression = originalMethodNode.ExpressionBody.Expression;
-        var statementFromExpr = SyntaxFactory
-          .ExpressionStatement(originalExpression);
-
+      var exprBodyExpr = editor.Generator.GetExpression(originalMethodNode) as ExpressionSyntax;
+      if (exprBodyExpr is not null) {
+        var statementFromExpr = SyntaxFactory.ExpressionStatement(exprBodyExpr);
         // Make sure to preserve the trailing trivia from the original method's semicolon token
         // If we don't do this we will lose any code comments or whitespace that was after the semicolon
         var originalMethodSemicolon = originalMethodNode.SemicolonToken;
@@ -105,27 +110,13 @@ public static class MethodModifier {
               );
           }
         }
-        statementsForNewBlock = statementsForNewBlock.Add(statementFromExpr);
-
-        // Remove the old expression body from the method
-        methodInProgress = methodInProgress
-            .WithExpressionBody(null)
-            .WithSemicolonToken(SyntaxFactory.Token(SyntaxKind.None));
+        statements.Add(statementFromExpr);
       }
-
-      // Add the provided statement
-      statementsForNewBlock = statementsForNewBlock.Add(statementToAdd);
-      // Create a new block with the collected statements
-      finalNewBody = SyntaxFactory
-        .Block(statementsForNewBlock);
     }
+    statements.Add(statementToAdd);
 
-    var fullyModifiedMethod = methodInProgress
-      .WithBody(finalNewBody)
-      .WithAdditionalAnnotations(Formatter.Annotation);
+    editor.SetStatements(originalMethodNode, statements);
 
-    // Replace the original method with the modified one in the type declaration
-    var newRoot = root.ReplaceNode(originalMethodNode, fullyModifiedMethod);
-    return document.WithSyntaxRoot(newRoot);
+    return editor.GetChangedDocument();
   }
 }


### PR DESCRIPTION
Using the DocumentEditor class instead of modifying syntax trees directly, as well as caching static syntax trees where possible, results in mild performance increases for the code fixes.

## Current Benchmarks (Before Change)
| Type                               | Method                            | Mean          | Error       | StdDev      | Median        | Ratio    | RatioSD  | Gen0      | Gen1      | Allocated    | Alloc Ratio |
|----------------------------------- |---------------------------------- |--------------:|------------:|------------:|--------------:|---------:|---------:|----------:|----------:|-------------:|------------:|
| NotificationFixBenchmark           | NotificationFix                   | 211,346.85 μs | 1,380.56 μs | 1,291.38 μs | 211,406.00 μs | 4,640.29 | 2,038.41 | 8000.0000 | 1000.0000 | 135001.52 KB |    4,285.76 |
| NotifyFixBenchmark                 | NotifyFix                         | 194,434.23 μs | 1,654.77 μs | 1,381.81 μs | 194,266.05 μs | 4,268.96 | 1,875.45 | 7000.0000 | 1000.0000 | 128973.48 KB |    4,094.40 |
| ProvideFixExistingMethodsBenchmark | ProvideFixExistingSetup           | 199,957.55 μs | 1,932.50 μs | 1,613.72 μs | 199,839.80 μs | 4,390.23 | 1,928.81 | 7000.0000 |         - | 129484.88 KB |    4,110.63 |
| ProvideFixNewMethodsBenchmark      | ProvideFixNewSetup                | 221,748.94 μs | 1,232.16 μs | 1,092.28 μs | 221,620.45 μs | 4,868.68 | 2,138.70 | 8000.0000 | 2000.0000 |  136877.8 KB |    4,345.33 |
| ProvideFixExistingMethodsBenchmark | ProvideFixExistingOnReady         | 195,541.62 μs |   921.38 μs |   719.35 μs | 195,748.05 μs | 4,293.27 | 1,885.99 | 7000.0000 | 1000.0000 |  129312.8 KB |    4,105.17 |
| ProvideFixNewMethodsBenchmark      | ProvideFixNewOnReady              | 220,897.49 μs | 1,955.46 μs | 1,733.46 μs | 220,628.85 μs | 4,849.98 | 2,130.72 | 8000.0000 | 2000.0000 | 136821.12 KB |    4,343.53 |
| ProvideFixExistingMethodsBenchmark | ProvideFixExistingReady           | 199,044.19 μs |   925.90 μs |   773.17 μs | 198,841.10 μs | 4,370.18 | 1,919.72 | 7000.0000 | 1000.0000 | 129275.34 KB |    4,103.98 |
| ProvideFixNewMethodsBenchmark      | ProvideFixNewReady                | 225,705.29 μs | 2,740.69 μs | 2,429.55 μs | 225,632.00 μs | 4,955.54 | 2,177.43 | 8000.0000 | 1000.0000 | 137130.23 KB |    4,353.34 |

## Updated Benchmarks (After Change)
| Type                               | Method                            | Mean          | Error        | StdDev      | Median        | Ratio    | RatioSD  | Gen0      | Gen1      | Allocated    | Alloc Ratio |
|----------------------------------- |---------------------------------- |--------------:|-------------:|------------:|--------------:|---------:|---------:|----------:|----------:|-------------:|------------:|
| NotificationFixBenchmark           | NotificationFix                   | 160,486.86 μs | 1,821.195 μs | 1,614.44 μs | 160,296.40 μs | 3,867.60 | 1,728.52 | 6000.0000 | 2000.0000 | 110707.91 KB |    3,514.54 |
| NotifyFixBenchmark                 | NotifyFix                         | 179,470.32 μs | 1,065.618 μs |   996.78 μs | 179,461.60 μs | 4,325.09 | 1,932.56 | 7000.0000 | 1000.0000 | 114999.85 KB |    3,650.79 |
| ProvideFixExistingMethodsBenchmark | ProvideFixExistingSetup           | 186,992.67 μs | 1,543.031 μs | 1,288.50 μs | 186,717.60 μs | 4,506.37 | 2,013.75 | 7000.0000 | 1000.0000 | 115910.01 KB |    3,679.68 |
| ProvideFixNewMethodsBenchmark      | ProvideFixNewSetup                | 178,469.68 μs | 1,364.425 μs | 1,209.53 μs | 178,125.70 μs | 4,300.98 | 1,921.91 | 7000.0000 | 2000.0000 | 114715.11 KB |    3,641.75 |
| ProvideFixExistingMethodsBenchmark | ProvideFixExistingOnReady         | 181,349.88 μs | 1,964.811 μs | 1,837.89 μs | 181,340.80 μs | 4,370.39 | 1,953.19 | 7000.0000 | 1000.0000 | 115617.56 KB |    3,670.40 |
| ProvideFixNewMethodsBenchmark      | ProvideFixNewOnReady              | 177,024.35 μs | 1,424.504 μs | 1,189.53 μs | 177,604.20 μs | 4,266.14 | 1,906.39 | 7000.0000 | 2000.0000 | 114672.21 KB |    3,640.39 |
| ProvideFixExistingMethodsBenchmark | ProvideFixExistingReady           | 187,872.30 μs | 1,361.200 μs | 1,062.74 μs | 187,803.75 μs | 4,527.57 | 2,023.20 | 7000.0000 | 1000.0000 | 115890.62 KB |    3,679.07 |
| ProvideFixNewMethodsBenchmark      | ProvideFixNewReady                | 177,974.32 μs | 1,200.186 μs | 1,002.21 μs | 178,021.20 μs | 4,289.04 | 1,916.55 | 7000.0000 | 1000.0000 |  115226.5 KB |    3,657.98 |
