### PR TITLE
perf: bump analyzer CodeAnalysis version

### DIFF
--- a/Chickensoft.AutoInject.Analyzers.PerformanceTests/Chickensoft.AutoInject.Analyzers.PerformanceTests.csproj
+++ b/Chickensoft.AutoInject.Analyzers.PerformanceTests/Chickensoft.AutoInject.Analyzers.PerformanceTests.csproj
@@ -2,7 +2,8 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>netstandard2.0</TargetFramework>
+    <LangVersion>preview</LangVersion>
     <ImplicitUsings>disable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <WarningAsError>NU1605</WarningAsError>
@@ -22,14 +23,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
-    <!-- should not be upgraded; we need CodeAnalysis v4.11 -->
-    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageReference Include="Nullable" Version="1.3.1">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="../Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj"/>
+    <ProjectReference Include="../Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj" />
   </ItemGroup>
 
 </Project>

--- a/Chickensoft.AutoInject.Analyzers.PerformanceTests/test/utils/BaselineAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers.PerformanceTests/test/utils/BaselineAnalyzer.cs
@@ -28,7 +28,13 @@ using System.Collections.Immutable;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.Diagnostics;
 
+// disabling RS1038 is necessary no matter how much the analyzer says it's not
+#pragma warning disable IDE0079
+// we're only using Workspaces in the code fixes, not the analyzers
+#pragma warning disable RS1038
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
+#pragma warning restore RS1038
+#pragma warning restore IDE0079
 public class BaselineAnalyzer : DiagnosticAnalyzer {
   public override ImmutableArray<DiagnosticDescriptor> SupportedDiagnostics => [];
 

--- a/Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
+++ b/Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
@@ -39,8 +39,8 @@
 
   <!-- The following libraries include the types we need -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
   </ItemGroup>
 
   <!-- This ensures the library will be packaged as an analyzer when we use `dotnet pack` -->

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotificationOverrideMissingAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotificationOverrideMissingAnalyzer.cs
@@ -8,7 +8,13 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
+// disabling RS1038 is necessary no matter how much the analyzer says it's not
+#pragma warning disable IDE0079
+// we're only using Workspaces in the code fixes, not the analyzers
+#pragma warning disable RS1038
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
+#pragma warning restore RS1038
+#pragma warning restore IDE0079
 public class AutoInjectNotificationOverrideMissingAnalyzer : DiagnosticAnalyzer {
   private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
     [Diagnostics.MissingAutoInjectNotificationOverrideDescriptor];

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyMissingAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectNotifyMissingAnalyzer.cs
@@ -8,7 +8,13 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using Microsoft.CodeAnalysis.Diagnostics;
 
+// disabling RS1038 is necessary no matter how much the analyzer says it's not
+#pragma warning disable IDE0079
+// we're only using Workspaces in the code fixes, not the analyzers
+#pragma warning disable RS1038
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
+#pragma warning restore RS1038
+#pragma warning restore IDE0079
 public class AutoInjectNotifyMissingAnalyzer : DiagnosticAnalyzer {
   private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
     [Diagnostics.MissingAutoInjectNotifyDescriptor];

--- a/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
+++ b/Chickensoft.AutoInject.Analyzers/src/AutoInjectProvideAnalyzer.cs
@@ -12,7 +12,13 @@ using Utils;
 /// When inheriting IProvide, the class must call this.Provide() somewhere in the setup.
 /// This analyzer checks that the class does not forget to call this.Provide().
 /// </summary>
+// disabling RS1038 is necessary no matter how much the analyzer says it's not
+#pragma warning disable IDE0079
+// we're only using Workspaces in the code fixes, not the analyzers
+#pragma warning disable RS1038
 [DiagnosticAnalyzer(LanguageNames.CSharp)]
+#pragma warning restore RS1038
+#pragma warning restore IDE0079
 public class AutoInjectProvideAnalyzer : DiagnosticAnalyzer {
   private static readonly ImmutableArray<DiagnosticDescriptor> _supportedDiagnostics =
     [Diagnostics.MissingAutoInjectProvideDescriptor];

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,4 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>chickensoft-games/renovate:godot"],
-  "ignoreDeps": ["BenchmarkDotNet"]
+  "extends": ["github>chickensoft-games/renovate:godot"]
 }


### PR DESCRIPTION
Bumped Analyzer package's version of CodeAnalysis packages to 4.14.0, to improve build performance in consuming projects. Because older versions of CodeAnalysis enable RS1022 by default, and the RS1022 analyzer uses slow techniques to detect violations, using the Analyzers package in consuming projects was resulting in very slow build times caused by CSharpDiagnosticAnalyzerApiUsageAnalyzer:

<img width="1097" height="79" alt="Screenshot 2025-07-31 165956" src="https://github.com/user-attachments/assets/c24beda5-0f85-4ec5-a151-5f848c6a4731" />

Newer versions of CodeAnalysis disable RS1022 by default, significantly improving build performance in consuming projects:

<img width="1135" height="105" alt="Screenshot 2025-07-31 171931" src="https://github.com/user-attachments/assets/a56e2bf5-30e7-42ec-8f77-48b929895dc0" />

See [this issue](https://redirect.github.com/dotnet/roslyn-analyzers/issues/6676), [this issue](https://redirect.github.com/dotnet/sdk/issues/33696), and [this document on RS1022](https://redirect.github.com/dotnet/roslyn-analyzers/blob/main/docs/rules/RS1022.md).

Also removed BenchmarkDotNet from renovate's ignore list, since it can now be kept up to date with newer versions of CodeAnalysis.