### PR TITLE
fix: roll back CodeAnalysis version

### DIFF
--- a/Chickensoft.AutoInject.Analyzers.PerformanceTests/Chickensoft.AutoInject.Analyzers.PerformanceTests.csproj
+++ b/Chickensoft.AutoInject.Analyzers.PerformanceTests/Chickensoft.AutoInject.Analyzers.PerformanceTests.csproj
@@ -23,9 +23,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
-    <PackageReference Include="BenchmarkDotNet" Version="0.15.2" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
     <PackageReference Include="Nullable" Version="1.3.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
+++ b/Chickensoft.AutoInject.Analyzers/Chickensoft.AutoInject.Analyzers.csproj
@@ -39,8 +39,8 @@
 
   <!-- The following libraries include the types we need -->
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.14.0" PrivateAssets="all" />
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.14.0" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.11.0" PrivateAssets="all" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="4.11.0" PrivateAssets="all" />
   </ItemGroup>
 
   <!-- This ensures the library will be packaged as an analyzer when we use `dotnet pack` -->

--- a/renovate.json
+++ b/renovate.json
@@ -1,4 +1,5 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>chickensoft-games/renovate:godot"]
+  "extends": ["github>chickensoft-games/renovate:godot"],
+  "ignoreDeps": ["BenchmarkDotNet"]
 }


### PR DESCRIPTION
CodeAnalysis 4.11.0 is the latest version available for .NET 8, and the recent bump to 4.14.0 (#69) causes warnings about compiler-version mismatches in consuming projects using .NET 8.

This change rolls back the Analyzers project's CodeAnalysis references to 4.11.0, but marks the Workspaces reference with `PrivateAssets="all"` to avoid transitive references causing slow builds in consuming projects.

It also rolls back the BenchmarkDotNet version in Analyzers.PerformanceTests for compatibility with CodeAnalysis 4.11.0 and re-marks BenchmarkDotNet as ignored in renovate.