### PR TITLE
fix: Fix and assert lifecycle hook order, extend test coverage

### DIFF
--- a/Chickensoft.AutoInject.Tests/src/auto_inject/dependent/AutoInject.cs
+++ b/Chickensoft.AutoInject.Tests/src/auto_inject/dependent/AutoInject.cs
@@ -14,11 +14,18 @@ public static class AutoInject
   /// <param name="fallbackProviderNode">
   /// The fallback dependency provider node or null to unset.
   /// </param>
-  public static void SetGlobalFallback(Node? fallbackProviderNode) =>
+  public static void SetGlobalFallback(Node? fallbackProviderNode)
+  {
+    if (fallbackProviderNode is null)
+    {
+      Engine.GetMainLoop().RemoveMeta(FALLBACK_INSTANCE_META_KEY);
+      return;
+    }
     Engine.GetMainLoop().SetMeta(
       FALLBACK_INSTANCE_META_KEY,
-      fallbackProviderNode ?? new Variant()
+      fallbackProviderNode
     );
+  }
 
 
   /// <summary>

--- a/Chickensoft.AutoInject.Tests/src/auto_inject/dependent/DependencyResolver.cs
+++ b/Chickensoft.AutoInject.Tests/src/auto_inject/dependent/DependencyResolver.cs
@@ -211,9 +211,10 @@ public static class DependencyResolver
     var foundDependencies = new HashSet<PropertyMetadata>();
     var providersInitializing = 0;
 
-    void resolve(bool deferred = false)
+
+    void resolve(bool afterReady = false)
     {
-      if (self.IsNodeReady() && !deferred)
+      if (self.IsNodeReady() && !afterReady)
       {
         // Godot node is already ready.
         if (!dependent.IsTesting)
@@ -326,7 +327,7 @@ public static class DependencyResolver
     if (state.Pending.Count == 0)
     {
       // Dependencies are already resolved, we can notify in OnAfterReady
-      resolve(deferred: true);
+      resolve(afterReady: true);
     }
 
     // We *could* check to see if a provider for every dependency was found

--- a/Chickensoft.AutoInject.Tests/src/auto_inject/dependent/DependencyResolver.cs
+++ b/Chickensoft.AutoInject.Tests/src/auto_inject/dependent/DependencyResolver.cs
@@ -211,9 +211,9 @@ public static class DependencyResolver
     var foundDependencies = new HashSet<PropertyMetadata>();
     var providersInitializing = 0;
 
-    void resolve()
+    void resolve(bool deferred = false)
     {
-      if (self.IsNodeReady())
+      if (self.IsNodeReady() && !deferred)
       {
         // Godot node is already ready.
         if (!dependent.IsTesting)
@@ -224,9 +224,7 @@ public static class DependencyResolver
         return;
       }
 
-      // Godot node is not ready yet, so we will wait for OnReady before
-      // calling Setup() and OnResolved().
-
+      // OnAfterReady will call Setup() and OnResolved().
       if (!dependent.IsTesting)
       {
         state.PleaseCallSetup = true;
@@ -327,8 +325,8 @@ public static class DependencyResolver
 
     if (state.Pending.Count == 0)
     {
-      // Inform dependent that dependencies have been resolved.
-      resolve();
+      // Dependencies are already resolved, we can notify in OnAfterReady
+      resolve(deferred: true);
     }
 
     // We *could* check to see if a provider for every dependency was found

--- a/Chickensoft.AutoInject.Tests/test/fixtures/Dependents.cs
+++ b/Chickensoft.AutoInject.Tests/test/fixtures/Dependents.cs
@@ -1,6 +1,7 @@
 namespace Chickensoft.AutoInject.Tests.Subjects;
 
 using System;
+using System.Collections.Generic;
 using Chickensoft.Introspection;
 using Godot;
 
@@ -154,4 +155,20 @@ public partial class NoDependenciesDependent : Node
   public bool OnResolvedCalled { get; private set; }
 
   public void OnResolved() => OnResolvedCalled = true;
+}
+
+[Meta(typeof(IAutoOn), typeof(IDependent))]
+public partial class OrderTrackingDependent : Node
+{
+  public override void _Notification(int what) => this.Notify(what);
+
+  [Dependency]
+  public string MyDependency => this.DependOn<string>();
+
+  public List<string> Calls { get; } = [];
+
+  public void Initialize() => Calls.Add(nameof(Initialize));
+  public void Setup() => Calls.Add(nameof(Setup));
+  public void OnReady() => Calls.Add(nameof(OnReady));
+  public void OnResolved() => Calls.Add(nameof(OnResolved));
 }

--- a/Chickensoft.AutoInject.Tests/test/src/EnhancedLifecycleTest.cs
+++ b/Chickensoft.AutoInject.Tests/test/src/EnhancedLifecycleTest.cs
@@ -1,0 +1,75 @@
+namespace Chickensoft.AutoInject.Tests;
+
+using System.Threading.Tasks;
+using Chickensoft.AutoInject.Tests.Subjects;
+using Chickensoft.GoDotTest;
+using Chickensoft.GodotTestDriver;
+using Godot;
+using Shouldly;
+
+public class EnhancedLifecycleTest(Node testScene) : TestClass(testScene)
+{
+  [Test]
+  public async Task HookOrderPreservedWhenSceneLoads()
+  {
+    // Children ready before ancestor provides dependencies.
+    await TestHookOrder(isSceneLoad: true);
+  }
+
+  [Test]
+  public async Task HookOrderPreservedWhenProvidersAlreadyInitialized()
+  {
+    // Ancestors provide dependencies before children ready.
+    await TestHookOrder(isSceneLoad: false);
+  }
+
+  [Test]
+  public async Task HookOrderPreservedWhenSceneLoadsInTesting()
+  {
+    // Children ready before ancestor provides dependencies in testing mode.
+    await TestHookOrder(isSceneLoad: true, isTesting: true);
+  }
+
+  [Test]
+  public async Task HookOrderPreservedInTestingWithProvidersAlreadyInitialized()
+  {
+    // Ancestors provide dependencies before children ready in testing mode.
+    await TestHookOrder(isSceneLoad: false, isTesting: true);
+  }
+
+  private async Task TestHookOrder(bool isSceneLoad, bool isTesting = false)
+  {
+    var provider = new StringProvider() { Value = "Hi" };
+    var fixture = new Fixture(TestScene.GetTree());
+    var dependent = new OrderTrackingDependent();
+    (dependent as IDependent)!.IsTesting = isTesting;
+
+    if (isSceneLoad)
+    {
+      provider.AddChild(dependent);
+      await fixture.AddToRoot(provider);
+    }
+    else
+    {
+      await fixture.AddToRoot(provider);
+      provider.AddChild(dependent);
+    }
+
+    // Wait until Godot dispatches NotificationReady to the new child.
+    await TestScene.GetTree().ToSignal(
+      TestScene.GetTree(), SceneTree.SignalName.ProcessFrame
+    );
+
+    // Skip Initialize and Setup in testing mode
+    string[] expectedCalls = isTesting
+      ? ["OnReady", "OnResolved"]
+      : ["Initialize", "OnReady", "Setup", "OnResolved"];
+    dependent.Calls.ShouldBe(expectedCalls);
+
+    await fixture.Cleanup();
+
+    provider.RemoveChild(dependent);
+    dependent.QueueFree();
+    provider.QueueFree();
+  }
+}

--- a/Chickensoft.AutoInject.Tests/test/src/ResolutionTest.cs
+++ b/Chickensoft.AutoInject.Tests/test/src/ResolutionTest.cs
@@ -386,6 +386,54 @@ public class ResolutionTest(Node testScene) : TestClass(testScene)
     obj.QueueFree();
   }
 
+  [Test]
+  public void ResolvesDependencyFromAnyProvider()
+  {
+    var value = "Hello, world!";
+    var provider = new AnyProvider
+    {
+      Values = new Dictionary<Type, object> {
+        { typeof(string), value }
+      }
+    };
+    var dependent = new StringDependent();
+
+    provider.AddChild(dependent);
+
+    provider._Notification((int)Node.NotificationReady);
+    dependent._Notification((int)Node.NotificationReady);
+
+    dependent.OnResolvedCalled.ShouldBeTrue();
+    dependent.ResolvedValue.ShouldBe(value);
+
+    provider.QueueFree();
+  }
+
+  [Test]
+  public void WalksAncestorsIntoGlobalFallbackWhenNotSatisfied()
+  {
+    var fallback = new IntProvider { Value = 10 };
+    fallback._Notification((int)Node.NotificationReady);
+
+    AutoInject.SetGlobalFallback(fallback);
+
+    var parent = new Node();
+    var dependent = new StringDependent();
+    parent.AddChild(dependent);
+
+    try
+    {
+      Should.Throw<ProviderNotFoundException>(
+        () => dependent._Notification((int)Node.NotificationReady)
+      );
+    }
+    finally
+    {
+      AutoInject.SetGlobalFallback(null);
+      parent.QueueFree();
+      fallback.QueueFree();
+    }
+  }
 
   public class BadProvider : IBaseProvider
   {


### PR DESCRIPTION
Addresses #143

Fixes the lifecycle hook invocation order to match the documentation: `Initialize() -> OnReady() -> Setup() -> OnResolved()` (or `OnReady() -> OnResolved()` when `IsTesting == true`).

Also expands test coverage to cover recently added branches for `IProvideAny` and `AutoInject`'s global fallback provider and actually unsets the meta value for the global fallback when you pass null.