### PR TITLE
Rename OnTreeExit to OnExitTree

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,7 +223,7 @@ public partial class MyDependent : Node
     MyValue.OnSomeEvent += ValueUpdated
   }
 
-  public void OnTreeExit()
+  public void OnExitTree()
   {
     // Clean up subscriptions here!
     MyValue.OnSomeEvent -= ValueUpdated


### PR DESCRIPTION
This PR fixes #178 by renaming the function in the README.